### PR TITLE
Added support for VECTORCAST_DIR 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to the "vectorcastTestExplorer" extension will be documented
 ## [1.0.2] - 2023-08-01
 
 ### Added support for VECTORCAST_DIR
-The VectorCAST instllation location can now be provided to the extension using one of the following 3 methods,
+The VectorCAST installation location can now be provided to the extension using one of the following 3 methods,
 and will be checked for by the extension in the following order
 - The path set in the extension option **Vcast Installation Location**
 - The path set via the VECTORCAST_DIR environment variable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,6 @@ All notable changes to the "vectorcastTestExplorer" extension will be documented
 ### Added support for VECTORCAST_DIR
 The VectorCAST installation location can now be provided to the extension using one of the following 3 methods,
 and will be checked for by the extension in the following order
-- The path set in the extension option **Vcast Installation Location**
+- The path set in the extension option **Vectorcast Installation Location**
 - The path set via the VECTORCAST_DIR environment variable
 - The system PATH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 All notable changes to the "vectorcastTestExplorer" extension will be documented in this file.
 
-## Relase History
+## Initial Release
 
 - 1.0.0 - Initial Release
 - 1.0.1 - Fixed repository link in README.md
+
+## [1.0.2] - 2023-08-01
+
+### Added support for VECTORCAST_DIR
+The VectorCAST instllation location can now be provided to the extension using one of the following 3 methods,
+and will be checked for by the extension in the following order
+- The path set in the extension option **Vcast Installation Location**
+- The path set via the VECTORCAST_DIR environment variable
+- The system PATH

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ as a margin decoration in C/C++ source editors.
 ## Prerequisites
 
 You must have VectorCAST installed and licensed, and the installation directory
-must either be on the **system PATH**, or set using the extension option: **VCAST Installation Location**
+must either be on the **system PATH**, set using the VECTORCAST_DIR environment variable
+or set using the extension option: **Vcast Installation Location**
 During extension activation, the prerequisites will be checked, and any errors
 reported in the VectorCAST Test Explorer output pane.
 
@@ -15,6 +16,11 @@ You can check if VectorCAST is on your path by:
 
 - Linux: open a shell, and type: which clicast
 - Windows: open a command prompt, and type: where clicast
+
+You can check if VECTORCAST_DIR is set properly by:
+
+- Linux: open a shell, and type: ls $VECTORCAST_DIR/clicast
+- Windows: open a command prompt, and type: dir %VECTORCAST_DIR%\clicast
 
 Additionally, if you are using a version of VectorCAST that is older than
 VectorCAST 23, you must manually add the crc32 utilities to your VectorCAST

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ as a margin decoration in C/C++ source editors.
 
 You must have VectorCAST installed and licensed, and the installation directory
 must either be on the **system PATH**, set using the VECTORCAST_DIR environment variable
-or set using the extension option: **Vcast Installation Location**
+or set using the extension option: **Vectorcast Installation Location**
 During extension activation, the prerequisites will be checked, and any errors
 reported in the VectorCAST Test Explorer output pane.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vectorcasttestexplorer",
   "displayName": "VectorCAST Test Explorer",
   "description": "VectorCAST Test Explorer for VS Code",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "See License in file: LICENSE",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
       "type": "object",
       "title": "VectorCAST Test Explorer",
       "properties": {
-        "vectorcastTestExplorer.vcastInstallationLocation": {
+        "vectorcastTestExplorer.vectorcastInstallationLocation": {
           "order": 1,
           "type": "string",
           "description": "Path to the VectorCAST installation, used if VectorCAST is not found on the system PATH"

--- a/server/pythonUtilities.ts
+++ b/server/pythonUtilities.ts
@@ -48,7 +48,7 @@ export function runPythonScript(enviroName: string, paramString: string): any {
   const commandToRun = `${vPythonCommandToUse} ${testEditorScriptPath} CLI ${enviroName} "${paramString}"`;
   const commandOutputBuffer = execSync(commandToRun).toString();
 
-  // vpython puts out this annoying VECTORCAST_DIR does not match
+  // vpython prints this annoying message if VECTORCAST_DIR does not match the executable
   // message to stdout when VC_DIR does not match the vcast distro being run.
   // Since this happens before our script even starts so we cannot suppress it.
   // We could send the json data to a temp file, but the create/open file operations

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,6 +76,10 @@ export async function activate(context: vscode.ExtensionContext) {
 let alreadyConfigured: boolean = false;
 export function checkPrerequisites(context: vscode.ExtensionContext) {
   if (!alreadyConfigured) {
+    
+    // setup the location of vTestInterface.py and other utilities
+    initializeInstallerFiles(context);
+
     if (checkIfInstallationIsOK()) {
       activationLogic(context);
       alreadyConfigured = true;
@@ -97,19 +101,6 @@ export function checkPrerequisites(context: vscode.ExtensionContext) {
 function activationLogic(context: vscode.ExtensionContext) {
   // adds all of the command handlers
   configureExtension(context);
-
-  // setup the location of vTestInterface.py
-  initializeInstallerFiles(context);
-
-  // must be called after initializeInstallerFiles()
-  // check if we have access to a valid crc32 command
-  if (!initializeChecksumCommand()) {
-    vscode.window.showWarningMessage(
-      "The VectorCAST Test Explorer could not find the required VectorCAST CRC-32 module, " +
-        "so the code coverage feature will not be available.  For details on how to resolve " +
-        "this issue, please refer to the 'Prerequisites' section of the README.md file."
-    );
-  }
 
   // setup the decorations for coverage
   initializeCodeCoverageFeatures(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -376,7 +376,7 @@ function configureExtension(context: vscode.ExtensionContext) {
     }
     if (
       event.affectsConfiguration(
-        "vectorcastTestExplorer.vcastInstallationLocation"
+        "vectorcastTestExplorer.vectorcastInstallationLocation"
       )
     ) {
       // if the user changes the path to vcast, we need to reset the values

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -113,7 +113,7 @@ function pyCrc32IsAvailable(): boolean {
 }
 
 
-function CRCutilityIsAvailable(vcastInstallationPath:string) {
+function getCRCutilityPath(vcastInstallationPath:string) {
 
   // check if the crc32 utility has been added to the the VectorCAST installation
 
@@ -134,7 +134,7 @@ export function initializeChecksumCommand(vcastInstallationPath:string): string 
     globalCheckSumCommand = `${vPythonCommandToUse} ${globalCrc32Path}`;
   } else {
     // check if the user has patched the distro with the crc32 utility
-    globalCheckSumCommand = CRCutilityIsAvailable(vcastInstallationPath);
+    globalCheckSumCommand = getCRCutilityPath(vcastInstallationPath);
   }
 
   return globalCheckSumCommand;

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -114,9 +114,9 @@ function CRCutilityIsAvailable() {
   // check if the crc32 utility has been added to the the VectorCAST installation
 
   // check the value of the option, I know this is extra work if
-  // the vcast installation is on the path but this is done once and it make the code cleaner
+  // the Vectorcast Installation is on the path but this is done once and it make the code cleaner
   const settings = vscode.workspace.getConfiguration("vectorcastTestExplorer");
-  const installationLocation = settings.get("vcastInstallationLocation", "");
+  const installationLocation = settings.get("vectorcastInstallationLocation", "");
 
   let returnValue: string | undefined = undefined;
   if (process.platform == "linux") {
@@ -397,7 +397,7 @@ function findVcastTools():boolean {
 
   // This function will set global paths to vpython, clicast and vcastqt
   // by sequentially looking for vpython in the directory set via the 
-  // 1. extension option: "vcastInstallationLocation"
+  // 1. extension option: "vectorcastInstallationLocation"
   // 2. VECTORCAST_DIR
   // 3. system PATH variable
 
@@ -407,7 +407,7 @@ function findVcastTools():boolean {
 
   // value of the extension option
   const settings = vscode.workspace.getConfiguration("vectorcastTestExplorer");
-  const installationOptionString = settings.get("vcastInstallationLocation", "");
+  const installationOptionString = settings.get("vectorcastInstallationLocation", "");
 
   // value of VECTORCAST_DIR
   const  VECTORCAST_DIR = process.env ["VECTORCAST_DIR"];
@@ -425,7 +425,7 @@ function findVcastTools():boolean {
     if (fs.existsSync(candidatePath)) {
       vcastInstallationPath = installationOptionString;
       vPythonCommandToUse = candidatePath;
-      vectorMessage(`   found '${vPythonName}' using the 'Vcast Installation Location' option [${installationOptionString}].`);
+      vectorMessage(`   found '${vPythonName}' using the 'Vectorcast Installation Location' option [${installationOptionString}].`);
     } else {
       vectorMessage(
         `   the installation path provided: '${installationOptionString}' does not contain ${vPythonName}, ` +

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -124,6 +124,9 @@ function getCRCutilityPath(vcastInstallationPath:string) {
         vectorMessage(`   found '${crc32Name}' here: ${vcastInstallationPath}`);
         returnValue = candidatePath;
       }
+      else {
+        vectorMessage(`   could NOT find '${crc32Name}' here: ${vcastInstallationPath}, coverage annotations will not be available`);
+      }
     }
   return returnValue;
 }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -12,7 +12,7 @@ const path = require("path");
 const which = require ("which")
 
 const vPythonName = "vpython";
-const vpythonOnPath = which.sync(vPythonName, { nothrow: true })
+const vpythonFromPath = which.sync(vPythonName, { nothrow: true })
 export let vPythonCommandToUse: string | undefined = undefined;
 
 const clicastName = "clicast";
@@ -403,7 +403,7 @@ function findVcastTools():boolean {
   // 3. system PATH variable
 
 
-  // return valuo
+  // return value
   let foundAllvcastTools = false;
 
   // value of the extension option
@@ -411,7 +411,7 @@ function findVcastTools():boolean {
   const installationOptionString = settings.get("vcastInstallationLocation", "");
 
   // value of VECTORCAST_DIR
-  const  vectorcastDirString = process.env ["VECTORCAST_DIR"];
+  const  VECTORCAST_DIR = process.env ["VECTORCAST_DIR"];
 
 
   // possible installation location
@@ -436,16 +436,16 @@ function findVcastTools():boolean {
     }
   } 
 
-  // priority 2 is VECTORCAST_DIR, while this is no longer required, is it still widely used
-  else if (vectorcastDirString) {
+  // priority 2 is VECTORCAST_DIR, while this is no longer required, it is still widely used
+  else if (VECTORCAST_DIR) {
     const candidatePath = path.join(
-      vectorcastDirString,
+      VECTORCAST_DIR,
       exeFilename(vPythonName)
     );
     if (fs.existsSync(candidatePath)) {
-      vcastInstallationPath = vectorcastDirString;
+      vcastInstallationPath = VECTORCAST_DIR;
       vPythonCommandToUse = candidatePath;
-      vectorMessage(`   found '${vPythonName}' using VECTORCAST_DIR [${vectorcastDirString}]`);
+      vectorMessage(`   found '${vPythonName}' using VECTORCAST_DIR [${VECTORCAST_DIR}]`);
     } else {
       vectorMessage(
         `   the installation path provided via VECTORCAST_DIR does not contain ${vPythonName}, ` +
@@ -456,9 +456,9 @@ function findVcastTools():boolean {
   } 
 
   // priority 3 is the system path
-  else if (vpythonOnPath) {
-    vcastInstallationPath = path.dirname (vpythonOnPath)
-    vPythonCommandToUse = vpythonOnPath;
+  else if (vpythonFromPath) {
+    vcastInstallationPath = path.dirname (vpythonFromPath)
+    vPythonCommandToUse = vpythonFromPath;
     vectorMessage(`   found '${vPythonName}' on the system path [${vcastInstallationPath}]`);
   } 
   

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -97,7 +97,7 @@ const win32CRC32 = "crc32-win32";
 
 function pyCrc32IsAvailable(): boolean {
   // Although crc32.py simply puts out AVAILABLE or NOT-AVAILABLE,
-  // vpython prints a long message of VECTORCAST_DIR is not set properly
+  // vpython prints this annoying message if VECTORCAST_DIR does not match the executable
   // so we need this logic to handle that case.
 
   // I'm doing this in multiple steps for clarity
@@ -253,9 +253,8 @@ export function executeVPythonScript(
   commandToRun: string,
   whereToRun: string
 ): any {
-  // we use this common functon to run the vpython and process the output
-  // primarily because vpython puts out this annoying VECTORCAST_DIR does not match
-  // message to stdout when VC_DIR does not match the vcast distro being run.
+  // we use this common functon to run the vpython and process the output because
+  // vpython prints this annoying message if VECTORCAST_DIR does not match the executable
   // Since this happens before our script even starts so we cannot suppress it.
   // We could send the json data to a temp file, but the create/open file operations
   // have overhead.

--- a/tests/internal/e2e/README.md
+++ b/tests/internal/e2e/README.md
@@ -20,7 +20,7 @@ Inside `internal/e2e/test/wdio.conf.ts`, we can specify some configuration param
 You should have `npm>=8.0` and `node>=16.9`. The following instructions were tested on `Ubuntu 20.04.4 LTS` with `npm==8.19.2` and `node==16.18.1`.
 
 You must have VectorCAST installed and licensed, and the installation directory
-must either be on the **system PATH**, or set using the extension option: **Vcast Installation Location**
+must either be on the **system PATH**, or set using the extension option: **Vectorcast Installation Location**
 During extension activation, the prerequisites will be checked, and any errors 
 reported in the VectorCAST Test Explorer output pane.
 

--- a/tests/internal/e2e/README.md
+++ b/tests/internal/e2e/README.md
@@ -20,7 +20,7 @@ Inside `internal/e2e/test/wdio.conf.ts`, we can specify some configuration param
 You should have `npm>=8.0` and `node>=16.9`. The following instructions were tested on `Ubuntu 20.04.4 LTS` with `npm==8.19.2` and `node==16.18.1`.
 
 You must have VectorCAST installed and licensed, and the installation directory
-must either be on the **system PATH**, or set using the extension option: **VCAST Installation Location**
+must either be on the **system PATH**, or set using the extension option: **Vcast Installation Location**
 During extension activation, the prerequisites will be checked, and any errors 
 reported in the VectorCAST Test Explorer output pane.
 


### PR DESCRIPTION
The extension now honors the setting of the VECTORCAST_DIR environment variable.  On startup, we will look for a VectorCAST installation directory in the following order:
- The path set in the extension option **VectorCAST Installation Location**
- The path set via the VECTORCAST_DIR environment variable
- The system PATH

We intentionally choose the give the "VectorCAST Installation Location" option the highest priority since this allows users to over-ride what might be set via the PATH or VECTORCAST_DIR variables.

As part of this change we reorganized some of the initialization processing to make the code cleaner, and updated some function names and comments along the way