### PR TITLE
Correct flow of extension to avoid reading from an undefined

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -114,11 +114,11 @@ function activationLogic(context: vscode.ExtensionContext) {
   // setup the decorations for coverage
   initializeCodeCoverageFeatures(context);
 
+  // initialize the gutter decorator for testable functions
+  initializeTestDecorator(context);
+
   // initialize the test pane
   activateTestPane(context);
-
-  // initialize the gutter decorator for testable functions
-  initializeTestDecorator (context);
 
   // start the language server
   activateLanguageServerClient(context);


### PR DESCRIPTION
This PR corrects the flow in `activationLogic` such that `initializeTestDecorator` is called before `updateTestDecorator`.

Closes #15 