### PR TITLE
Hover over anonymous struct or union fields results in odd __T<number> type name

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,7 +28,7 @@
         "--mode=getEnviroData",
         "--kind=vcast",
         "--clicast=C:/vcast/vc23sp2/clicast.exe",
-        "--path=c:/RDS/SandBox/VectorCAST/examples/unitTests/FOO"
+        "--path=c:/RDS/SandBox/VectorCAST/CodeBasedTests/unitTests/TEST"
       ],
       "console": "integratedTerminal"
     },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,7 +28,7 @@
         "--mode=getEnviroData",
         "--kind=vcast",
         "--clicast=C:/vcast/vc23sp2/clicast.exe",
-        "--path=c:/RDS/SandBox/VectorCAST/CodeBasedTests/unitTests/TEST"
+        "--path=c:/RDS/SandBox/VectorCAST/examples/unitTests/FOO"
       ],
       "console": "integratedTerminal"
     },
@@ -54,14 +54,14 @@
       "type": "python",
       "request": "launch",
       "program": "${workspaceFolder}/python/testEditorInterface.py",
-      "cwd": "C:/RDS/SandBox/VectorCAST/examples/unitTests",
+      "cwd": "C:/RDS/SandBox/VCAST-NEW/vcastTutorial/cpp/unitTests",
       "env": {
-        "PYTHONPATH": "C:/vcast/vc23sp2/python"
+        "PYTHONPATH": "C:/vcast/vc23/python"
       },
       "args": [
         "CLI",
-        "C:\\RDS\\SandBox\\VectorCAST\\examples\\unitTests\\STRUCT",
-        "TEST.VALUE:struct.foo.x.f.f"
+        "C:\\RDS\\SandBox\\VCAST-NEW\\vcastTutorial\\cpp\\unitTests\\MANAGER",
+        "TEST.VALUE:manager.Manager::PlaceOrder.Order.Entree:"
       ],
       "console": "integratedTerminal"
     },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -54,14 +54,14 @@
       "type": "python",
       "request": "launch",
       "program": "${workspaceFolder}/python/testEditorInterface.py",
-      "cwd": "C:/RDS/SandBox/VCAST-NEW/vcastTutorial/cpp/unitTests",
+      "cwd": "C:/RDS/SandBox/VectorCAST/examples/unitTests",
       "env": {
-        "PYTHONPATH": "C:/vcast/vc23/python"
+        "PYTHONPATH": "C:/vcast/vc23sp2/python"
       },
       "args": [
         "CLI",
-        "C:\\RDS\\SandBox\\VCAST-NEW\\vcastTutorial\\cpp\\unitTests\\MANAGER",
-        "TEST.VALUE:manager.Manager::PlaceOrder.Order.Entree:"
+        "C:\\RDS\\SandBox\\VectorCAST\\examples\\unitTests\\STRUCT",
+        "TEST.VALUE:struct.foo.x.f.f"
       ],
       "console": "integratedTerminal"
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,3 +44,11 @@ This option is new for VectorCAST 23 sp2
 - Fixed issue: Auto completion not working properly in some cases #9
 - Fixed issue: VectorCAST context menu is incorrectly added to non VectorCAST nodes #11
 - Fixed test tree update issue: that caused the test tree to not update after a load or delete action.  Caused by the VS Code 1.81 release.
+
+## [1.0.5] - 2023-09-14
+
+- Added "Programming Languages" to the "categories" in the manifest so that the extension will get suggested for .tst files.
+
+### Bug Fixes
+- Fixed issue: Hover over for anonymous structs and unions show internal type names #17
+- Fixed stack trace display when VectorCAST environment version is incompatible with VectorCAST installation

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "publisher": "vectorgroup",
   "categories": [
     "Testing",
-    "Debuggers"
+    "Programming Languages",
+    "Snippets"
   ],
   "bugs": {
     "url": "https://github.com/vectorgrp/vector-vscode-vcast/issues"
@@ -338,7 +339,8 @@
       {
         "id": "vcast.tst",
         "aliases": [
-          "VectorCAST Test Script"
+          "TST",
+          "tst"
         ],
         "extensions": [
           ".tst"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vectorcasttestexplorer",
   "displayName": "VectorCAST Test Explorer",
   "description": "VectorCAST Test Explorer for VS Code",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "license": "See License in file: LICENSE",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -339,6 +339,7 @@
       {
         "id": "vcast.tst",
         "aliases": [
+          "VectorCAST Test Script",
           "TST",
           "tst"
         ],

--- a/python/crc32.py
+++ b/python/crc32.py
@@ -1,29 +1,26 @@
-
 import os
 import sys
 
 # See the comment in: executeVPythonScript()
-print ("ACTUAL-DATA")
+print("ACTUAL-DATA")
 
 try:
     # only vcast 23 and higher have pychksum
     import pycksum
 except:
-    print ("NOT-AVAILABLE")
-    sys.exit (0)
+    print("NOT-AVAILABLE")
+    sys.exit(0)
 
 
-def main ():
-   
-    if len (sys.argv)==1:
+def main():
+    if len(sys.argv) == 1:
         # no filePath means the caller is just checking if pycksum is available
-        print ("AVAILABLE")
-    elif (os.path.exists (sys.argv[1])):
-        print (pycksum.cksum(open(sys.argv[1], 'rb')))
+        print("AVAILABLE")
+    elif os.path.exists(sys.argv[1]):
+        print(pycksum.cksum(open(sys.argv[1], "rb")))
     else:
-        print (0)
+        print(0)
+
 
 if __name__ == "__main__":
     main()
-
-

--- a/python/testEditorInterface.py
+++ b/python/testEditorInterface.py
@@ -1,4 +1,3 @@
-
 """
 //////////////////////////////////////////////////////////////////////////////
 this started life as a duplicate of:  dataAPIInterface/testEditorInterface.py
@@ -46,11 +45,11 @@ def main():
     outputDictionary = dict()
     outputDictionary["choiceKind"] = choiceData.choiceKind
     outputDictionary["choiceList"] = choiceData.choiceList
-    outputDictionary["messages"] = globalOutputLog 
+    outputDictionary["messages"] = globalOutputLog
 
     # See the comment in: runPythonScript()
-    print ("ACTUAL-DATA")
-    print (json.dumps (outputDictionary, indent=4))
+    print("ACTUAL-DATA")
+    print(json.dumps(outputDictionary, indent=4))
 
     sys.exit(0)
 

--- a/python/tstUtilities.py
+++ b/python/tstUtilities.py
@@ -79,10 +79,11 @@ def getTypeDisplayName (type):
     """
 
     # The anon names are always __T<address> so use regex
-    if re.search("^__T[0-9]+$", type.display_name):
-        return type.typemark
-    else:
-        return type.display_name
+    returnValue = type.display_name
+    if re.match("__T[0-9]", returnValue):
+        returnValue = type.typemark
+    
+    return returnValue
 
 
 def additionalTypeInfo(type):

--- a/python/tstUtilities.py
+++ b/python/tstUtilities.py
@@ -66,21 +66,34 @@ def getObjectFromName(objectList, name):
     return None
 
 
+def getTypeDisplayName (type):
+    """
+    In some cases the "display_name" is a generated temporary or tag-name
+    this happens for anon structures in C for example
+    
+    typedef struct {
+        int a;
+        } myType;
+
+    In that case, use use the typemark vs display_name
+    """
+
+    # The anon names are always __T<address> so use regex
+    if re.search("^__T[0-9]+$", type.display_name):
+        return type.typemark
+    else:
+        return type.display_name
+
 
 def additionalTypeInfo(type):
     """
     For some types, we want to give a hint about the kind ...
     """
+
     if type.kind == "REC_ORD":
-        if re.search("^__T[0-9]+$", type.display_name):
-            # We have a generated temporary or tag-name
-            # this happens for anon structures in C for example
-            # typedef struct {int a;} myType;
-            return type.typemark + "(struct)"
-        else:
-            return type.display_name + "(struct)"
+        return getTypeDisplayName (type) + "(struct)"
     elif type.kind == "UNION":
-        return type.display_name + "(union)"
+        return getTypeDisplayName (type) +  "(union)"
     elif type.kind == "CLASS":
         return type.display_name + "(class)"
     elif type.kind in ["POINTER", "CLASS_PTR", "ACCE_SS"]:

--- a/python/tstUtilities.py
+++ b/python/tstUtilities.py
@@ -72,7 +72,13 @@ def additionalTypeInfo(type):
     For some types, we want to give a hint about the kind ...
     """
     if type.kind == "REC_ORD":
-        return type.display_name + "(struct)"
+        if re.search("^__T[0-9]+$", type.display_name):
+            # We have a generated temporary or tag-name
+            # this happens for anon structures in C for example
+            # typedef struct {int a;} myType;
+            return type.typemark + "(struct)"
+        else:
+            return type.display_name + "(struct)"
     elif type.kind == "UNION":
         return type.display_name + "(union)"
     elif type.kind == "CLASS":

--- a/python/tstUtilities.py
+++ b/python/tstUtilities.py
@@ -1,4 +1,3 @@
-
 """
 //////////////////////////////////////////////////////////////////////////////
 this started life as a duplicate of:  dataAPIInterface/tstUtilities.py
@@ -24,9 +23,9 @@ def getNameListFromObjectList(objectList):
     """
     returnList = list()
     for object in objectList:
-        if isinstance (object, Function):
+        if isinstance(object, Function):
             # vcast_name has the overloaded name if needed.
-            returnList.append (object.vcast_name)
+            returnList.append(object.vcast_name)
         else:
             returnList.append(object.name)
 
@@ -40,12 +39,12 @@ def getNameListFromItemList(paramOrObjectList):
     """
     returnList = list()
     for object in paramOrObjectList:
-        if isinstance (object, Global):
+        if isinstance(object, Global):
             # Improvement needed: need to handle class instance objects here
             listItem = object.name + "@" + additionalTypeInfo(object.type)
         else:
             typeInfo = additionalTypeInfo(object.type)
-            if typeInfo.endswith ("*") or typeInfo.endswith("]"):
+            if typeInfo.endswith("*") or typeInfo.endswith("]"):
                 listItem = object.name + "[0]@" + typeInfo
             else:
                 listItem = object.name + "@" + typeInfo
@@ -56,21 +55,20 @@ def getNameListFromItemList(paramOrObjectList):
 
 
 def getObjectFromName(objectList, name):
-
     for object in objectList:
         # function names might be overloaded
-        if isinstance (object, Function) and object.vcast_name == name:
+        if isinstance(object, Function) and object.vcast_name == name:
             return object
         elif object.name == name:
             return object
     return None
 
 
-def getTypeDisplayName (type):
+def getTypeDisplayName(type):
     """
     In some cases the "display_name" is a generated temporary or tag-name
     this happens for anon structures in C for example
-    
+
     typedef struct {
         int a;
         } myType;
@@ -82,7 +80,7 @@ def getTypeDisplayName (type):
     returnValue = type.display_name
     if re.match("__T[0-9]", returnValue):
         returnValue = type.typemark
-    
+
     return returnValue
 
 
@@ -92,9 +90,9 @@ def additionalTypeInfo(type):
     """
 
     if type.kind == "REC_ORD":
-        return getTypeDisplayName (type) + "(struct)"
+        return getTypeDisplayName(type) + "(struct)"
     elif type.kind == "UNION":
-        return getTypeDisplayName (type) +  "(union)"
+        return getTypeDisplayName(type) + "(union)"
     elif type.kind == "CLASS":
         return type.display_name + "(class)"
     elif type.kind in ["POINTER", "CLASS_PTR", "ACCE_SS"]:
@@ -207,14 +205,13 @@ def processType(type, commandPieces, currentIndex, triggerCharacter):
 
     elif typeClassification == "string":
         if triggerCharacter == ":":
-             returnData.choiceList.append("string")
-             returnData.choiceKind = choiceKindType.Constant
+            returnData.choiceList.append("string")
+            returnData.choiceKind = choiceKindType.Constant
 
     elif typeClassification == "char":
         if triggerCharacter == ":":
-             returnData.choiceList.append("scalar@character")
-             returnData.choiceKind = choiceKindType.Constant
-
+            returnData.choiceList.append("scalar@character")
+            returnData.choiceKind = choiceKindType.Constant
 
     elif typeClassification == "struct":
         fieldObjectList = list()
@@ -224,13 +221,13 @@ def processType(type, commandPieces, currentIndex, triggerCharacter):
             fieldObjectList.append(f)
             fieldNameList.append(f.name)
             typeInfo = additionalTypeInfo(f.type)
-            if typeInfo.endswith("*") or typeInfo.endswith ("]"):
+            if typeInfo.endswith("*") or typeInfo.endswith("]"):
                 choiceList.append(f.name + "[0]@" + typeInfo)
             else:
                 choiceList.append(f.name + "@" + typeInfo)
         if len(commandPieces) == currentIndex + 1:
-             returnData.choiceList = choiceList
-             returnData.choiceKind = choiceKindType.Field
+            returnData.choiceList = choiceList
+            returnData.choiceKind = choiceKindType.Field
 
         else:
             currentField = commandPieces[currentIndex].split("[")[0]
@@ -267,9 +264,8 @@ def processType(type, commandPieces, currentIndex, triggerCharacter):
 
     elif typeClassification in ["int", "float"]:
         if triggerCharacter == ":":
-             returnData.choiceList.append("scalar@number")
-             returnData.choiceKind = choiceKindType.Constant
-
+            returnData.choiceList.append("scalar@number")
+            returnData.choiceKind = choiceKindType.Constant
 
     else:  # "other" case
         globalOutputLog.append("processtype ignored type: " + type.kind)
@@ -280,8 +276,7 @@ def processType(type, commandPieces, currentIndex, triggerCharacter):
 tagForGlobals = "<<GLOBAL>>"
 
 
-
-def getFunctionList (api, unitName):
+def getFunctionList(api, unitName):
     """
     common code to generate list of functions ...
     """
@@ -293,24 +288,23 @@ def getFunctionList (api, unitName):
         returnList = getNameListFromObjectList(functionList)
         # seems like a vcast dataAPI bug, that <<INIT>> is in this list
         if "<<INIT>>" in returnList:
-            returnList.remove ("<<INIT>>")
+            returnList.remove("<<INIT>>")
         if len(unitObject.globals) > 0:
             returnList.append(tagForGlobals)
 
     return returnList
 
 
-def getTestList (api, unitName, functionName):
-
+def getTestList(api, unitName, functionName):
     returnList = list()
     unitObject = getObjectFromName(api.Unit.all(), unitName)
     if unitObject:
         functionObject = getObjectFromName(unitObject.functions, functionName)
         if functionObject:
             for testObject in functionObject.testcases:
-                returnList.append (testObject.name)
+                returnList.append(testObject.name)
 
-    if len (returnList)>0:
+    if len(returnList) > 0:
         return returnList
     else:
         return ["no test cases exist"]
@@ -319,34 +313,35 @@ def getTestList (api, unitName, functionName):
 # choiceKindType should match the VS Code CompletionItemKind type
 # Surprisingly there is no "parameter" kind, so I just use Field for parameters
 class choiceKindType(str, Enum):
-    Constant='Constant'
-    Enum='Enum'
-    Field='Field',
-    File='File',
-    Function='Function',
-    Keyword='Keyword',
-    Property='Property'
-    Value='Value'
-    Variable='Variable'
+    Constant = "Constant"
+    Enum = "Enum"
+    Field = ("Field",)
+    File = ("File",)
+    Function = ("Function",)
+    Keyword = ("Keyword",)
+    Property = "Property"
+    Value = "Value"
+    Variable = "Variable"
+
 
 class choiceDataType:
     choiceList = list()
     choiceKind = choiceKindType.Keyword
 
 
-def processSlotLines (api, pieces, triggerCharacter):
+def processSlotLines(api, pieces, triggerCharacter):
     """
     This function handles slot lines that look like this:
        TEST.SLOT: 1, manager, Manager::PlaceOrder, 1, Manager::PlaceOrder.001
     """
 
     global globalOutputLog
-    returnData = choiceDataType();
+    returnData = choiceDataType()
 
     lengthOfCommand = len(pieces)
 
     if lengthOfCommand == 2 and triggerCharacter == ":":  # Slot Number
-        returnData.choiceList.append ("<slot-number>")
+        returnData.choiceList.append("<slot-number>")
         returnData.choiceKind = choiceKindType.Constant
 
     elif lengthOfCommand == 3 and triggerCharacter == ",":  # Unit
@@ -354,27 +349,24 @@ def processSlotLines (api, pieces, triggerCharacter):
         returnData.choiceList = getNameListFromObjectList(objectList)
         returnData.choiceKind = choiceKindType.File
 
-
-    elif  lengthOfCommand == 4 and triggerCharacter == ",":  # function
-        returnData.choiceList = getFunctionList (api, pieces[2])
+    elif lengthOfCommand == 4 and triggerCharacter == ",":  # function
+        returnData.choiceList = getFunctionList(api, pieces[2])
         returnData.choiceKind = choiceKindType.Function
 
-
-    elif  lengthOfCommand == 5 and triggerCharacter == ",":  # iterations
-        returnData.choiceList.append ("<iteration-count>")
+    elif lengthOfCommand == 5 and triggerCharacter == ",":  # iterations
+        returnData.choiceList.append("<iteration-count>")
         returnData.choiceKind = choiceKindType.Constant
 
-    elif  lengthOfCommand == 6 and triggerCharacter == ",":  # test-case
+    elif lengthOfCommand == 6 and triggerCharacter == ",":  # test-case
         unitName = pieces[2]
         functionName = pieces[3]
-        returnData.choiceList = getTestList (api, unitName, functionName)
+        returnData.choiceList = getTestList(api, unitName, functionName)
         returnData.choiceKind = choiceKindType.Property
-
 
     return returnData
 
 
-def processStandardLines (api, pieces, triggerCharacter):
+def processStandardLines(api, pieces, triggerCharacter):
     """
     This function process everything except TEST.SLOT lines
     """
@@ -394,10 +386,12 @@ def processStandardLines (api, pieces, triggerCharacter):
         returnData.choiceKind = choiceKindType.File
 
     elif lengthOfCommand == 4 and triggerCharacter == ".":  # Function
-        returnData.choiceList = getFunctionList (api, pieces[2])
+        returnData.choiceList = getFunctionList(api, pieces[2])
         returnData.choiceKind = choiceKindType.Function
 
-    elif (lengthOfCommand == 5 and triggerCharacter == "."):  # parameters and global objects
+    elif (
+        lengthOfCommand == 5 and triggerCharacter == "."
+    ):  # parameters and global objects
         unitName = pieces[2]
         unitObject = getObjectFromName(api.Unit.all(), unitName)
         functionList = unitObject.functions
@@ -432,20 +426,20 @@ def processStandardLines (api, pieces, triggerCharacter):
             itemObject = getObjectFromName(paramList, paramName)
 
         # we pass index 5 to walk the parameter type
-        if (itemObject):
+        if itemObject:
             returnData = processType(itemObject.type, pieces, 5, triggerCharacter)
 
     return returnData
 
 
-def splitExistingLine (line):
+def splitExistingLine(line):
     """
-    We need to split the input line based on delimiters: '.' ':' ',' 
-    comma is only for slots so to support this and do the 
+    We need to split the input line based on delimiters: '.' ':' ','
+    comma is only for slots so to support this and do the
     right thing when there are overloaded functions we do this in parts
     """
 
-    if line.upper().startswith ("TEST.SLOT"):
+    if line.upper().startswith("TEST.SLOT"):
         # split by : and , but ignore , in ()
         pieces = re.split("(?<!:)[:\,](?!:)(?![^\(]*\))", line)
     else:
@@ -480,7 +474,6 @@ def processLine(enviroName, line):
     global globalOutputLog
 
     try:
-
         globalOutputLog.append("Processing: '" + line + "' ...")
 
         # open the environment ...
@@ -504,10 +497,10 @@ def processLine(enviroName, line):
 
         # when we get here, the last element in the list of pieces will always be ""
 
-        if line.upper().startswith ("TEST.SLOT"):
-            returnData = processSlotLines (api, pieces, triggerCharacter)
+        if line.upper().startswith("TEST.SLOT"):
+            returnData = processSlotLines(api, pieces, triggerCharacter)
         else:
-            returnData = processStandardLines (api, pieces, triggerCharacter)
+            returnData = processStandardLines(api, pieces, triggerCharacter)
 
         return returnData
 

--- a/python/vTestInterface.py
+++ b/python/vTestInterface.py
@@ -140,8 +140,13 @@ import inspect
 
 def getTestDataVCAST(enviroPath):
 
-    api = UnitTestApi(enviroPath)
-
+    # dataAPI throws if there is a tool/enviro missmatch
+    try:
+        api = UnitTestApi(enviroPath)
+    except Exception as err:
+        print (err)
+        raise Exception("INVALID_ENVIRO")
+    
     testList = list()
     sourceFiles = dict()
 
@@ -524,8 +529,14 @@ if __name__ == "__main__":
 
     except Exception as err:
         # for usage error we print the issue where we see it
-        if str(err) != "USAGE_ERROR":
+        if str(err) not in ["USAGE_ERROR", "INVALID_ENVIRO"]:
             traceBackText = traceback.format_exc()
             print(traceBackText)
-        # in all cases return error code != 0
-        sys.exit(1)
+
+        # We treat invalid enviro as a warning
+        if str(err) in ["INVALID_ENVIRO"]:
+
+            sys.exit (99)
+        else:
+            # in all other cases return error code 1
+            sys.exit(1)

--- a/python/vTestInterface.py
+++ b/python/vTestInterface.py
@@ -147,7 +147,7 @@ import inspect
 
 def getTestDataVCAST(enviroPath):
 
-    # dataAPI throws if there is a tool/enviro missmatch
+    # dataAPI throws if there is a tool/enviro mismatch
     try:
         api = UnitTestApi(enviroPath)
     except Exception as err:

--- a/python/vTestInterface.py
+++ b/python/vTestInterface.py
@@ -26,6 +26,7 @@ from vector.apps.DataAPI.unit_test_api import UnitTestApi
 from vector.apps.DataAPI.cover_api import CoverApi
 from vector.lib.core.system import cd
 
+
 class InvalidEnviro(Exception):
     pass
 
@@ -57,11 +58,7 @@ def setupArgs():
         help="Environment Kind",
     )
 
-    parser.add_argument(
-        "--clicast",
-        required=True,
-        help="Path to clicast to use"
-    )
+    parser.add_argument("--clicast", required=True, help="Path to clicast to use")
 
     parser.add_argument(
         "--path",
@@ -104,7 +101,6 @@ def getTime(time):
 
 
 def XofYString(numerator, denominator):
-
     if numerator == 0 or denominator == 0:
         return ""
     else:
@@ -146,14 +142,13 @@ import inspect
 
 
 def getTestDataVCAST(enviroPath):
-
     # dataAPI throws if there is a tool/enviro mismatch
     try:
         api = UnitTestApi(enviroPath)
     except Exception as err:
-        print (err)
+        print(err)
         raise InvalidEnviro()
-    
+
     testList = list()
     sourceFiles = dict()
 
@@ -189,7 +184,7 @@ def getTestDataVCAST(enviroPath):
         for function in unit.functions:
             functionNode = dict()
             # Seems like a vcast dataAPI bug with manager.cpp
-            if function.vcast_name!="<<INIT>>":
+            if function.vcast_name != "<<INIT>>":
                 # Note: the vcast_name has the parameterization only when there is an overload
                 functionNode["name"] = function.vcast_name
                 functionNode["tests"] = list()
@@ -202,11 +197,10 @@ def getTestDataVCAST(enviroPath):
 
                 unitNode["functions"].append(functionNode)
 
-        if len (unitNode["functions"])>0:
+        if len(unitNode["functions"]) > 0:
             testList.append(unitNode)
 
     return testList
-
 
 
 def printCoverageListing(enviroPath):
@@ -230,7 +224,7 @@ def printCoverageListing(enviroPath):
 
     sourceObjects = capi.SourceFile.all()
     for sourceObject in sourceObjects:
-        sys.stdout.write ("=" * 100 + "\n")
+        sys.stdout.write("=" * 100 + "\n")
         for line in sourceObject.iterate_coverage():
             sys.stdout.write(str(line.line_number).ljust(line_num_width))
             sys.stdout.write(line._cov_line.covered_char() + " | " + line.text + "\n")
@@ -250,7 +244,7 @@ def getUnitData(enviroPath, kind):
             raise UsageError()
 
         # For testing/debugging
-        #printCoverageListing (enviroPath)
+        # printCoverageListing (enviroPath)
 
         sourceObjects = capi.SourceFile.all()
         for sourceObject in sourceObjects:
@@ -258,7 +252,7 @@ def getUnitData(enviroPath, kind):
             covered, uncovered, checksum = getCoverageData(sourceObject)
             unitInfo = dict()
             unitInfo["path"] = sourcePath
-            unitInfo["functionList"] = getFunctionData (sourceObject)
+            unitInfo["functionList"] = getFunctionData(sourceObject)
             unitInfo["cmcChecksum"] = checksum
             unitInfo["covered"] = covered
             unitInfo["uncovered"] = uncovered
@@ -267,7 +261,7 @@ def getUnitData(enviroPath, kind):
     return unitList
 
 
-def getFunctionData (sourceObject):
+def getFunctionData(sourceObject):
     """
     This function will return info about the functions in a source file
     """
@@ -294,7 +288,7 @@ def getCoverageData(sourceObject):
         if sourceObject.has_cover_data:
             # if iterate_coverage crashes if the original
             # file path does not exist.
-            if os.path.exists (sourceObject.path):
+            if os.path.exists(sourceObject.path):
                 for line in sourceObject.iterate_coverage():
                     covLine = line._cov_line
                     covChar = covLine.covered_char()
@@ -307,14 +301,14 @@ def getCoverageData(sourceObject):
                 coveredString = coveredString[:-1]
                 uncoveredString = uncoveredString[:-1]
 
-
-
     return coveredString, uncoveredString, checksum
 
 
 commandFileName = "commands.cmd"
 
 globalClicastCommand = ""
+
+
 def runClicastScript(commandFileName):
     """
     The caller should create a correctly formatted clicast script
@@ -335,12 +329,11 @@ def runClicastScript(commandFileName):
 
 
 def getStandardArgsFromTestObject(testIDObject):
-
-    returnString = f'-e {testIDObject.enviroName}'
+    returnString = f"-e {testIDObject.enviroName}"
     if testIDObject.unitName != "not-used":
-        returnString += f' -u{testIDObject.unitName}'
-    returnString += f' -s{testIDObject.functionName}'
-    returnString += f' -t{testIDObject.testName}'
+        returnString += f" -u{testIDObject.unitName}"
+    returnString += f" -s{testIDObject.functionName}"
+    returnString += f" -t{testIDObject.testName}"
     return returnString
 
 
@@ -380,7 +373,6 @@ def runTestCommand(testIDObject, commandList):
 
 
 def executeVCtest(enviroPath, testIDObject):
-
     with cd(os.path.dirname(enviroPath)):
         commands = list()
         commands.append("execute")
@@ -404,7 +396,6 @@ def executeVCtest(enviroPath, testIDObject):
 
 
 def processVResults(filePath):
-
     if os.path.isfile(filePath):
         with open(filePath, "r") as file:
             lineList = file.readlines()
@@ -460,7 +451,6 @@ def executeCodeBasedTest(enviroPath, testID):
 
 
 def getResults(enviroPath, testIDObject):
-
     with cd(os.path.dirname(enviroPath)):
         commands = list()
         commands.append("results")
@@ -486,7 +476,6 @@ class testID:
 
 
 def main():
-
     global globalClicastCommand
 
     argParser = setupArgs()
@@ -499,7 +488,7 @@ def main():
     enviroPath = os.path.abspath(args.path)
 
     # See the comment in: executeVPythonScript()
-    print ("ACTUAL-DATA")
+    print("ACTUAL-DATA")
 
     if args.mode == "getEnviroData":
         topLevel = dict()
@@ -533,7 +522,6 @@ def main():
 
 
 if __name__ == "__main__":
-
     # Exit with 1 by default
     returnCode = 1
 

--- a/python/vTestInterface.py
+++ b/python/vTestInterface.py
@@ -26,6 +26,13 @@ from vector.apps.DataAPI.unit_test_api import UnitTestApi
 from vector.apps.DataAPI.cover_api import CoverApi
 from vector.lib.core.system import cd
 
+class InvalidEnviro(Exception):
+    pass
+
+
+class UsageError(Exception):
+    pass
+
 
 def setupArgs():
     """
@@ -145,7 +152,7 @@ def getTestDataVCAST(enviroPath):
         api = UnitTestApi(enviroPath)
     except Exception as err:
         print (err)
-        raise Exception("INVALID_ENVIRO")
+        raise InvalidEnviro()
     
     testList = list()
     sourceFiles = dict()
@@ -240,7 +247,7 @@ def getUnitData(enviroPath, kind):
             capi = CoverApi(enviroPath)
         except Exception as err:
             print(err)
-            raise Exception("USAGE_ERROR")
+            raise UsageError()
 
         # For testing/debugging
         #printCoverageListing (enviroPath)
@@ -521,22 +528,26 @@ def main():
         print("Unknown mode value: " + args.mode)
         print("Valid modes are: getEnviroData, getCoverageData, executeTest, results")
 
+    # Zero exit code
+    return 0
+
 
 if __name__ == "__main__":
+
+    # Exit with 1 by default
+    returnCode = 1
+
     try:
-        main()
-        sys.exit(0)
-
-    except Exception as err:
-        # for usage error we print the issue where we see it
-        if str(err) not in ["USAGE_ERROR", "INVALID_ENVIRO"]:
-            traceBackText = traceback.format_exc()
-            print(traceBackText)
-
+        returnCode = main()
+    except InvalidEnviro:
         # We treat invalid enviro as a warning
-        if str(err) in ["INVALID_ENVIRO"]:
+        returnCode = 99
+    except UsageError:
+        # for usage error we print the issue where we see it
+        returnCode = 1
+    except Exception:
+        traceBackText = traceback.format_exc()
+        print(traceBackText)
+        returnCode = 1
 
-            sys.exit (99)
-        else:
-            # in all other cases return error code 1
-            sys.exit(1)
+    sys.exit(returnCode)

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -359,7 +359,13 @@ export function executeCommand(
         .trim();
     else commandStatus.stdout = execSync(commandToRun).toString().trim();
   } catch (error: any) {
-    if (error && error.stdout) {
+    // 99 is a warning, like a missmatch opening the environment
+    if (error && error.status == 99) {
+      commandStatus.stdout = error.stdout.toString();
+      commandStatus.errorCode = 0;
+      vectorMessage(commandStatus.stdout);
+    }
+    else if (error && error.stdout) {
       commandStatus.stdout = error.stdout.toString();
       commandStatus.errorCode = error.status;
       if (printErrorDetails) {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -359,7 +359,7 @@ export function executeCommand(
         .trim();
     else commandStatus.stdout = execSync(commandToRun).toString().trim();
   } catch (error: any) {
-    // 99 is a warning, like a missmatch opening the environment
+    // 99 is a warning, like a mismatch opening the environment
     if (error && error.status == 99) {
       commandStatus.stdout = error.stdout.toString();
       commandStatus.errorCode = 0;


### PR DESCRIPTION
- Fix hover over for anonymous structs and unions show internal type names
- Fix stack trace display when VectorCAST environment version is incompatible with VectorCAST installation

Closes #17
