### PR TITLE
Fix missing quotes in `--test` argument when forming `testInterfaceCommand`

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -88,7 +88,7 @@ export function testInterfaceCommand(
           enviroName = enviroPath.substring(enviroPath.lastIndexOf("/") + 1, enviroPath.length);
       }
       // The -test arguments should be the enviro name along with everything after the |
-      testArgument = ` --test="${enviroName}|${testID.split ('|')[1]}`; 
+      testArgument = ` --test="${enviroName}|${testID.split ('|')[1]}"`; 
     }
     return command + testArgument;
 

--- a/tests/internal/e2e/test/specs/vcast.test.ts
+++ b/tests/internal/e2e/test/specs/vcast.test.ts
@@ -491,7 +491,7 @@ describe("vTypeCheck VS Code Extension", () => {
     ).toBe(true);
     expect(
       outputViewText.includes(
-        "test explorer  [info]  Test summary for: cpp/unitTests/DATABASE-MANAGER|manager.Manager::PlaceOrder.myFirstTest",
+        "test explorer  [info]  Test summary for: vcast:cpp/unitTests/DATABASE-MANAGER|manager.Manager::PlaceOrder.myFirstTest",
       ),
     ).toBe(true);
     expect(
@@ -548,8 +548,8 @@ describe("vTypeCheck VS Code Extension", () => {
 
     editorView = workbench.getEditorView();
     const tab = (await editorView.openEditor("manager.cpp")) as TextEditor;
-    const RED_GUTTER = "/no-gutter-icon";
-    const GREEN_GUTTER = "/gutter-icon";
+    const RED_GUTTER = "/no-cover-icon";
+    const GREEN_GUTTER = "/cover-icon";
     // moving cursor to make sure coverage indicators are in view
     await tab.moveCursor(10, 3);
     console.log(
@@ -786,7 +786,7 @@ describe("vTypeCheck VS Code Extension", () => {
     ).toBe(true);
     expect(
       outputViewText.includes(
-        "test explorer  [info]  Test summary for: cpp/unitTests/DATABASE-MANAGER|manager.Manager::PlaceOrder.mySecondTest",
+        "test explorer  [info]  Test summary for: vcast:cpp/unitTests/DATABASE-MANAGER|manager.Manager::PlaceOrder.mySecondTest",
       ),
     ).toBe(true);
     expect(
@@ -1016,7 +1016,7 @@ describe("vTypeCheck VS Code Extension", () => {
     ).toBe(true);
     expect(
       outputViewText.includes(
-        "test explorer  [info]  Test summary for: cpp/unitTests/DATABASE-MANAGER|manager.Manager::PlaceOrder.myThirdTest",
+        "test explorer  [info]  Test summary for: vcast:cpp/unitTests/DATABASE-MANAGER|manager.Manager::PlaceOrder.myThirdTest",
       ),
     ).toBe(true);
     expect(


### PR DESCRIPTION
Running `testInterfaceCommand` in E2E tests failed with `Unterminated quoted string`
- After adding the missing quote, all tests pass
- Committed changes to expected output of E2E tests
  - Relying on terminal output here, hence `vcast:` in the log  