### PR TITLE
Avoid overwriting CCAST_.CFG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,3 +60,9 @@ This option is new for VectorCAST 23 sp2
 - Fixed issue:  New test scripts should have TEST.NEW not TEST.REPLACE #20
 - Fixed issue:  Added ENVIRO.STUB: ALL_BY_PROTOTYPE to environment script #21
 - Fixed issue:  Execute error when enviro at root of workspace #22
+
+## [1.0.7] - 2023-10-06
+
+### Bug Fixes
+- Fixed issue: Do not overwrite an existing `CCAST_.CFG` if one exists #25
+

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vectorcasttestexplorer",
   "displayName": "VectorCAST Test Explorer",
   "description": "VectorCAST Test Explorer for VS Code",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "license": "See License in file: LICENSE",
   "repository": {
     "type": "git",

--- a/src/vcastTestInterface.ts
+++ b/src/vcastTestInterface.ts
@@ -545,12 +545,6 @@ function buildEnvironmentVCAST(
     fileList
   );
 
-  // we need to wait for this to complete, so we use executeCommand
-  executeCommand(
-    `${clicastCommandToUse} -lc template GNU_CPP_X`,
-    unitTestLocation
-  );
-
   // this call will run clicast in the background
   const clicastArgs = ["-lc", "env", "build", envFilePath];
   // This is long running commands so we open the message pane to give the user a sense of what is going on.


### PR DESCRIPTION
This PR changes `vector-vscode-vcast` such that we do not overwrite an existing `CCAST_.CFG` if one already exists.

Before this PR:

* `buildEnvironmentVCAST` -> always creates a `CCAST_.CFG` (overwriting an existing one) -> calls `executeClicastCommand` -> `executeClicastCommand` checks for a `CCAST_.CFG` and creates one if it doesn't exist (but it does, because `buildEnvironmentVCAST` always makes one)

After this PR:

* `buildEnvironmentVCAST` -> calls `executeClicastCommand` -> `executeClicastCommand` checks for a `CCAST_.CFG` and creates one if it doesn't exist (makes one if it doesn't exist, doesn't touch it if does)

Closes #25 
