### PR TITLE
Bumped minimal required vscode version to 1.74

### DIFF
--- a/package.json
+++ b/package.json
@@ -376,7 +376,7 @@
     "@types/glob": "^7.1.4",
     "@types/mocha": "^9.0.0",
     "@types/node": "16.x",
-    "@types/vscode": "^1.73.1",
+    "@types/vscode": "^1.74.0",
     "@typescript-eslint/eslint-plugin": "^5.59.0",
     "@typescript-eslint/parser": "^5.59.0",
     "@vscode/test-electron": "^1.6.2",
@@ -405,6 +405,6 @@
   },
   "extensionDependencies": [],
   "engines": {
-    "vscode": "^1.73.1"
+    "vscode": "^1.74.0"
   }
 }

--- a/tests/internal/e2e/test/wdio.conf.ts
+++ b/tests/internal/e2e/test/wdio.conf.ts
@@ -147,7 +147,7 @@ export const config: Options.Testrunner = {
         proxyType: "manual",
         httpProxy: process.env["http_proxy"],
       },
-      browserVersion: "1.79.0",
+      browserVersion: "1.74.0",
       acceptInsecureCerts: true,
       "wdio:vscodeOptions": {
         extensionPath: path.join(process.env["INIT_CWD"], "test", "extension"),


### PR DESCRIPTION
- Minimal required `vscode` version is `1.74` now
- Set internal `e2e` tests to run on `vscode 1.74`