### PR TITLE
E2E tests for RGW support

### DIFF
--- a/tests/internal/e2e/package.json
+++ b/tests/internal/e2e/package.json
@@ -23,6 +23,7 @@
         "@wdio/cli": "^8.6.5",
         "eslint": "^8.35.0",
         "eslint-config-prettier": "^8.7.0",
-        "eslint-plugin-prettier": "^4.2.1"
+        "eslint-plugin-prettier": "^4.2.1",
+        "vscode-uri":"3.0.7"
     }
 }

--- a/tests/internal/e2e/test/specs/vcast.test.ts
+++ b/tests/internal/e2e/test/specs/vcast.test.ts
@@ -322,7 +322,7 @@ describe("vTypeCheck VS Code Extension", () => {
       throw "Subprogram 'manager' not found";
     }
 
-    let subprogramMethod = await findSubprogramMethod(
+    const subprogramMethod = await findSubprogramMethod(
       subprogram,
       "Manager::PlaceOrder",
     );
@@ -335,7 +335,7 @@ describe("vTypeCheck VS Code Extension", () => {
     }
     await openTestScriptFor(subprogramMethod);
 
-    let tab = (await editorView.openEditor(
+    const tab = (await editorView.openEditor(
       "vcast-template.tst",
     )) as TextEditor;
     console.log("Getting content assist");

--- a/tests/internal/e2e/test/specs/vcast.test.ts
+++ b/tests/internal/e2e/test/specs/vcast.test.ts
@@ -271,6 +271,7 @@ describe("vTypeCheck VS Code Extension", () => {
 
     // Checking if the output opened in the bottom bar
     // with VectorCAST Test Explorer channel
+    await editorView.closeAllEditors()
     const selectBox = await $(".monaco-select-box");
     const selectedChannel = await selectBox.getValue();
     expect(selectedChannel).toBe("VectorCAST Test Explorer");
@@ -321,7 +322,7 @@ describe("vTypeCheck VS Code Extension", () => {
       throw "Subprogram 'manager' not found";
     }
 
-    const subprogramMethod = await findSubprogramMethod(
+    let subprogramMethod = await findSubprogramMethod(
       subprogram,
       "Manager::PlaceOrder",
     );
@@ -334,7 +335,7 @@ describe("vTypeCheck VS Code Extension", () => {
     }
     await openTestScriptFor(subprogramMethod);
 
-    const tab = (await editorView.openEditor(
+    let tab = (await editorView.openEditor(
       "vcast-template.tst",
     )) as TextEditor;
     console.log("Getting content assist");
@@ -350,7 +351,28 @@ describe("vTypeCheck VS Code Extension", () => {
     await findWidget.setReplaceText("TEST.NAME:myFirstTest");
     await findWidget.replace();
     await browser.keys([Key.Escape]);
-    let currentLine = await tab.getLineOfText("TEST.VALUE");
+
+    let currentLine = await tab.getLineOfText("TEST.NAME:myFirstTest");
+    await tab.moveCursor(
+      currentLine,
+      "TEST.NAME:myFirstTest".length + 1,
+    );
+    await browser.keys([Key.Enter]);
+    currentLine += 1;
+    
+    await tab.setTextAtLine(
+      currentLine,
+      "TEST.REQUIREMENT_KEY:FR20 | Clearing a table resets orders for all seats",
+    );
+    
+    await tab.moveCursor(
+      currentLine,
+      "TEST.REQUIREMENT_KEY:FR20 | Clearing a table resets orders for all seats".length + 1,
+    );
+    await browser.keys([Key.Enter]);
+    
+
+    currentLine = await tab.getLineOfText("TEST.VALUE");
     await tab.typeTextAt(currentLine, "TEST.VALUE".length + 1, ":");
 
     // Really important to wait until content assist appears
@@ -426,6 +448,7 @@ describe("vTypeCheck VS Code Extension", () => {
     await browser.executeWorkbench((vscode) => {
       vscode.commands.executeCommand("vectorcastTestExplorer.loadTestScript");
     });
+
   });
 
   it("should run myFirstTest and check its report", async () => {
@@ -644,6 +667,12 @@ describe("vTypeCheck VS Code Extension", () => {
     const tab = (await editorView.openEditor(
       "DATABASE-MANAGER.tst",
     )) as TextEditor;
+    let currentLine = await tab.getLineOfText("TEST.REQUIREMENT_KEY:FR20");
+    const reqTooltipText = await getGeneratedTooltipTextAt(currentLine, "TEST.REQUIREMENT_KEY:FR20".length - 1, tab);
+    console.log(reqTooltipText);
+    expect(reqTooltipText).toContain("Clearing a table resets orders for all seats");
+    expect(reqTooltipText).toContain("Clearing a table clears the orders for all seats of the table within the table database.");
+
     const findWidget = await tab.openFindWidget();
     await findWidget.setSearchText("TEST.NAME:myFirstTest");
     await findWidget.toggleReplace(true);
@@ -654,7 +683,7 @@ describe("vTypeCheck VS Code Extension", () => {
     await bottomBar.toggle(false);
     const lastValueLineInPreviousTest =
       "TEST.VALUE:manager.Manager::PlaceOrder.Order.Entree:Steak";
-    let currentLine = await tab.getLineOfText(lastValueLineInPreviousTest);
+    currentLine = await tab.getLineOfText(lastValueLineInPreviousTest);
     await tab.moveCursor(currentLine, lastValueLineInPreviousTest.length + 1);
     await browser.keys(Key.Enter);
     await tab.save();
@@ -923,8 +952,12 @@ describe("vTypeCheck VS Code Extension", () => {
 
     const expectedProblemText = 'Commands cannot be nested in a "NOTES" block';
     const problemsView = await bottomBar.openProblemsView();
+    await browser.waitUntil(
+      async () => (await problemsView.getAllMarkers()).length > 0,
+      { timeout: TIMEOUT },
+    );
     const problemMarkers = await problemsView.getAllMarkers();
-    console.log(await problemMarkers[0].getText());
+    // console.log(await problemMarkers[0].getText());
     // problem markers can appear for new features
     let nestedCommandProblemFound = false;
     for (const problem of problemMarkers[0].problems) {

--- a/tests/internal/e2e/test/wdio.conf.ts
+++ b/tests/internal/e2e/test/wdio.conf.ts
@@ -393,9 +393,38 @@ export const config: Options.Testrunner = {
     else createLaunchJson = `touch ${launchJsonPath}`;
     await promisifiedExec(createLaunchJson);
     
-    const CCAST_CFG_PATH = path.join(testInputVcastTutorial,"CCAST_.CFG")
-    const createCFG = "clicast -lc template GNU_CPP_X"
+    
+    const createCFG = `cd ${testInputVcastTutorial} && clicast -lc template GNU_CPP_X`
     await promisifiedExec(createCFG);
+    
+  
+    const reqTutorialPath = path.join(vectorcastDir, "examples", "RequirementsGW", "CSV_Requirements_For_Tutorial.csv") 
+    const commandPrefix = `cd ${testInputVcastTutorial} && ${clicastExecutablePath.trimEnd()} -lc`
+    const rgwPrepCommands = [
+      `${commandPrefix} option VCAST_REPOSITORY ${path.join(initialWorkdir, "test","vcastTutorial")}`,
+      `${commandPrefix} RGw INitialize`,
+      `${commandPrefix} Rgw Set Gateway CSV`,
+      `${commandPrefix} RGw Configure Set CSV csv_path ${reqTutorialPath}`,
+      `${commandPrefix} RGw Configure Set CSV use_attribute_filter 0`,
+      `${commandPrefix} RGw Configure Set CSV filter_attribute`, 
+      `${commandPrefix} RGw Configure Set CSV filter_attribute_value `,
+      `${commandPrefix} RGw Configure Set CSV id_attribute ID`,
+      `${commandPrefix} RGw Configure Set CSV key_attribute Key`,
+      `${commandPrefix} RGw Configure Set CSV title_attribute Title `,
+      `${commandPrefix} RGw Configure Set CSV description_attribute Description `,
+      `${commandPrefix} RGw Import`
+    ]
+    for (const rgwPrepCommand of rgwPrepCommands) {
+      const { stdout, stderr } = await promisifiedExec(rgwPrepCommand);
+      if (stderr) {
+        console.log(stderr);
+        throw `Error when running ${rgwPrepCommand}`;
+      }
+      console.log(stdout);
+    }
+
+
+
 
     const pathToTutorial = path.join(vectorcastDir, "tutorial", "cpp");
     await mkdir(pathToTutorial, { recursive: true });
@@ -404,7 +433,6 @@ export const config: Options.Testrunner = {
 
     // copying didn't work with cp from fs
     if (process.platform == "win32") {
-      await promisifiedExec(`xcopy /s /i /y CCAST_.CFG ${testInputVcastTutorial} > NUL 2> NUL`,)
       await promisifiedExec(
         `xcopy /s /i /y ${cppFilesToCopy} ${testInputEnvPath} > NUL 2> NUL`,
       );
@@ -419,7 +447,6 @@ export const config: Options.Testrunner = {
         )}`,
       );
     } else {
-      await promisifiedExec(`cp CCAST_.CFG ${testInputVcastTutorial}`);
       await promisifiedExec(`cp ${cppFilesToCopy} ${testInputEnvPath}`);
       await promisifiedExec(`cp ${headerFilesToCopy} ${testInputEnvPath}`);
       await promisifiedExec(


### PR DESCRIPTION
- added E2E tests for RGW support and did some cleanup
- includes a hover over `TEST.REQUIREMENT_KEY:FR20` to check if the requirements info appears after the test is loaded