### PR TITLE
Fix for issue: #64, improve colors for user code expected values

### DIFF
--- a/src/reporting.ts
+++ b/src/reporting.ts
@@ -53,8 +53,8 @@ tr:hover {
     overflow: scroll;
 }
 
-.danger {
-    background-color: var(--vscode-testing-iconFailed);
+.danger, .bg-danger {
+    background-color: var(--vscode-minimap-errorHighlight);
     color: black;
     font-weight: bold
 }

--- a/src/reporting.ts
+++ b/src/reporting.ts
@@ -59,8 +59,8 @@ tr:hover {
     font-weight: bold
 }
 
-.danger:hover {
-    background-color: var(--vscode-testing-iconFailed) !important;
+.danger:hover, .bg-danger:hover {
+    background-color: var(--vscode-minimap-errorHighlight) !important;
 }
 
 .success, .bg-success {


### PR DESCRIPTION
When testing #55, I noticed that the failure colours for coded tests looked very bad in dark mode. The issue was that the error colour was "too light", while the text was also light, making it very hard to read.

This PR changes the extension such that we correctly handle `.bg-danger`, as well as choosing a slightly more "punchy" colour for the error colour (which I feel works better between the two themes).