### PR TITLE
E2E tests for coded test support 

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -204,6 +204,7 @@ export function addLaunchConfiguration(fileUri: Uri) {
   } else {
     existingJSON.configurations.push(vectorConfiguration);
     fs.writeFileSync(jsonPath, JSON.stringify(existingJSON, null, "\t"));
+  
   }
 }
 

--- a/tests/internal/e2e/test/specs/vcast.test.ts
+++ b/tests/internal/e2e/test/specs/vcast.test.ts
@@ -1319,7 +1319,7 @@ describe("vTypeCheck VS Code Extension", () => {
     await editorView.closeEditor("VectorCAST Report", 1);
   });
 
-  it("should prepare for debugging", async () => {
+  it("should prepare for debugging with coverage turned ON", async () => {
     await updateTestID();
 
     const activityBar = workbench.getActivityBar();
@@ -1408,6 +1408,92 @@ describe("vTypeCheck VS Code Extension", () => {
     expect(activeTabTitle).toBe("manager_inst.cpp");
 
     console.log("Finished creating debug configuration");
+  });
+
+  it("should prepare for debugging with coverage turned OFF", async () => {
+    await updateTestID();
+    console.log("Turning off coverage")
+    {
+      const turnOffCoverageCmd = "cd test/vcastTutorial/cpp/unitTests && clicast -e DATABASE-MANAGER tools coverage disable"
+      const { stdout, stderr } = await promisifiedExec(turnOffCoverageCmd);
+        
+      if (stderr) {
+        console.log(stderr);
+        throw `Error when running ${turnOffCoverageCmd}`;
+      }
+      console.log(stdout)
+    }
+    const activityBar = workbench.getActivityBar();
+    const explorerView = await activityBar.getViewControl("Explorer");
+    const explorerSideBarView = await explorerView?.openView();
+
+    const workspaceFolderName = "vcastTutorial";
+    const workspaceFolderSection = await explorerSideBarView
+      .getContent()
+      .getSection(workspaceFolderName.toUpperCase());
+    console.log(await workspaceFolderSection.getTitle());
+    await workspaceFolderSection.expand();
+
+    console.log("Looking for Manager::PlaceOrder in the test tree");
+    const vcastTestingViewContent = await getViewContent("Testing");
+
+    console.log("Expanding all test groups");
+    let subprogram: TreeItem = undefined;
+    let testHandle: TreeItem = undefined;
+    for (const vcastTestingViewSection of await vcastTestingViewContent.getSections()) {
+      subprogram = await findSubprogram("manager", vcastTestingViewSection);
+      if (subprogram) {
+        await subprogram.expand();
+        testHandle = await getTestHandle(
+          subprogram,
+          "Manager::PlaceOrder",
+          "myFirstTest",
+          3,
+        );
+        if (testHandle) {
+          break;
+        } else {
+          throw "Test handle not found for myFirstTest";
+        }
+      }
+    }
+
+    if (!subprogram) {
+      throw "Subprogram 'manager' not found";
+    }
+
+    console.log("Debugging myFirstTest");
+    console.log("Clicking on Debug Test button");
+    await testHandle.select();
+    await (await (await testHandle.getActionButton("Debug Test")).elem).click();
+    console.log("Validating debug notifications");
+
+    console.log("Waiting for manager_vcast.cpp to be open");
+    // this times out if manager_vcast.cpp is not ready
+    await browser.waitUntil(
+      async () =>
+        (await (await editorView.getActiveTab()).getTitle()) ===
+        "manager_vcast.cpp",
+      { timeout: TIMEOUT },
+    );
+    const activeTab = await editorView.getActiveTab();
+    const activeTabTitle = await activeTab.getTitle();
+    console.log(activeTabTitle);
+    expect(activeTabTitle).toBe("manager_vcast.cpp");
+
+    console.log("Finished creating debug configuration");
+    console.log("Turning coverage back on")
+    {
+      const turnOffCoverageCmd = "cd test/vcastTutorial/cpp/unitTests && clicast -e DATABASE-MANAGER tools coverage enable"
+      const { stdout, stderr } = await promisifiedExec(turnOffCoverageCmd);
+        
+      if (stderr) {
+        console.log(stderr);
+        throw `Error when running ${turnOffCoverageCmd}`;
+      }
+      console.log(stdout)
+    }
+
   });
 
   it("Verifies that gutter decorations dissapear when we edit manager.cpp", async () => {
@@ -1526,8 +1612,11 @@ describe("vTypeCheck VS Code Extension", () => {
   it("should build VectorCAST environment from .env", async () => {
     await updateTestID();
     const workbench = await browser.getWorkbench();
+    const editorView = workbench.getEditorView()
+    await editorView.closeAllEditors()
     const activityBar = workbench.getActivityBar();
-    await (await bottomBar.openOutputView()).clearText()
+    const outputView = await bottomBar.openOutputView();
+    await outputView.clearText()
     
     const explorerView = await activityBar.getViewControl("Explorer");
     await explorerView?.openView();
@@ -1543,7 +1632,7 @@ describe("vTypeCheck VS Code Extension", () => {
     await bottomBar.maximize()
     await browser.waitUntil(
       async () =>
-        (await (await bottomBar.openOutputView()).getText())
+        (await outputView.getText())
           .toString()
           .includes("Environment built Successfully"),
       { timeout: TIMEOUT },

--- a/tests/internal/e2e/test/specs/vcast.test.ts
+++ b/tests/internal/e2e/test/specs/vcast.test.ts
@@ -1596,5 +1596,9 @@ describe("vTypeCheck VS Code Extension", () => {
     }
 
   });
-
+  it("should clean up", async () => {
+    await updateTestID();
+    await cleanup()
+    
+  });
 });

--- a/tests/internal/e2e/test/specs/vcast.test.ts
+++ b/tests/internal/e2e/test/specs/vcast.test.ts
@@ -1394,18 +1394,18 @@ describe("vTypeCheck VS Code Extension", () => {
     // this will timeout if debugger is not ready and/or debugger notification text is not shown
     await $(debugNotificationText);
 
-    console.log("Waiting for manager_vcast.cpp to be open");
+    console.log("Waiting for manager_inst.cpp to be open");
     // this times out if manager_vcast.cpp is not ready
     await browser.waitUntil(
       async () =>
         (await (await editorView.getActiveTab()).getTitle()) ===
-        "manager_vcast.cpp",
+        "manager_inst.cpp",
       { timeout: TIMEOUT },
     );
     const activeTab = await editorView.getActiveTab();
     const activeTabTitle = await activeTab.getTitle();
     console.log(activeTabTitle);
-    expect(activeTabTitle).toBe("manager_vcast.cpp");
+    expect(activeTabTitle).toBe("manager_inst.cpp");
 
     console.log("Finished creating debug configuration");
   });

--- a/tests/internal/e2e/test/specs/vcast_coded_tests.test.ts
+++ b/tests/internal/e2e/test/specs/vcast_coded_tests.test.ts
@@ -1,0 +1,297 @@
+// test/specs/vcast.test.ts
+import {
+  BottomBarPanel,
+  StatusBar,
+  TextEditor,
+  EditorView,
+  CustomTreeItem,
+  Workbench,
+  TreeItem,
+} from "wdio-vscode-service";
+import { Key } from "webdriverio";
+import {
+  releaseCtrl,
+  executeCtrlClickOn,
+  expandWorkspaceFolderSectionInExplorer,
+  clickOnButtonInTestingHeader,
+  getGeneratedTooltipTextAt,
+  getViewContent,
+  findSubprogram,
+  getTestHandle,
+  findSubprogramMethod,
+  openTestScriptFor,
+  editTestScriptFor,
+  deleteTest,
+  updateTestID,
+  cleanup
+} from "../test_utils/vcast_utils";
+
+import { exec } from "child_process";
+import { promisify } from "node:util";
+const promisifiedExec = promisify(exec);
+describe("vTypeCheck VS Code Extension", () => {
+  let bottomBar: BottomBarPanel;
+  let workbench: Workbench;
+  let editorView: EditorView;
+  let statusBar: StatusBar;
+  const TIMEOUT = 120000;
+  before(async () => {
+    workbench = await browser.getWorkbench();
+    // opening bottom bar and problems view before running any tests
+    bottomBar = workbench.getBottomBar();
+    await bottomBar.toggle(true);
+    editorView = workbench.getEditorView();
+    process.env["E2E_TEST_ID"] = "0";
+  });
+
+  it("test 1: should be able to load VS Code", async () => {
+    await updateTestID();
+    expect(await workbench.getTitleBar().getTitle()).toBe(
+      "[Extension Development Host] vcastTutorial - Visual Studio Code",
+    );
+  });
+
+  it("should activate vcastAdapter", async () => {
+    await updateTestID();
+
+    await browser.keys([Key.Control, Key.Shift, "p"]);
+    // Typing Vector in the quick input box
+    // This brings up VectorCAST Test Explorer: Configure
+    // so just need to hit Enter to activate
+    for (const character of "vector") {
+      await browser.keys(character);
+    }
+    await browser.keys(Key.Enter);
+
+    const activityBar = workbench.getActivityBar();
+    const viewControls = await activityBar.getViewControls();
+    for (const viewControl of viewControls) {
+      console.log(await viewControl.getTitle());
+    }
+    await bottomBar.toggle(true);
+    const outputView = await bottomBar.openOutputView();
+
+    console.log("Waiting for VectorCAST activation");
+    await $("aria/VectorCAST Test Pane Initialization");
+    console.log("WAITING FOR TESTING");
+    await browser.waitUntil(
+      async () => (await activityBar.getViewControl("Testing")) !== undefined,
+      { timeout: TIMEOUT },
+    );
+    console.log("WAITING FOR TEST EXPLORER");
+    await browser.waitUntil(async () =>
+      (await outputView.getChannelNames())
+        .toString()
+        .includes("VectorCAST Test Explorer")
+    );
+    await outputView.selectChannel("VectorCAST Test Explorer")
+    console.log("Channel selected")
+    console.log("WAITING FOR LANGUAGE SERVER");
+    await browser.waitUntil(
+      async () =>
+        (await outputView.getText())
+          .toString()
+          .includes("Starting the language server"),
+      { timeout: TIMEOUT },
+    );
+
+    const testingView = await activityBar.getViewControl("Testing");
+    await testingView?.openView();
+  });
+
+  it("should set default config file", async () => {
+    await updateTestID();
+
+    const workbench = await browser.getWorkbench();
+    const activityBar = workbench.getActivityBar();
+    const explorerView = await activityBar.getViewControl("Explorer");
+    await explorerView?.openView();
+
+    const workspaceFolderSection = await expandWorkspaceFolderSectionInExplorer(
+      "vcastTutorial",
+    );
+
+    const configFile = await workspaceFolderSection.findItem("CCAST_.CFG")
+    await configFile.openContextMenu()
+    await (await $("aria/Set as VectorCAST Configuration File")).click()
+  });
+
+  it("should create VectorCAST environment", async () => {
+    await updateTestID();
+
+    const workbench = await browser.getWorkbench();
+    const activityBar = workbench.getActivityBar();
+    const explorerView = await activityBar.getViewControl("Explorer");
+    await explorerView?.openView();
+
+    const workspaceFolderSection = await expandWorkspaceFolderSectionInExplorer(
+      "vcastTutorial",
+    );
+    const cppFolder = workspaceFolderSection.findItem("cpp");
+    await (await cppFolder).select();
+
+    let managerCpp = await workspaceFolderSection.findItem("manager.cpp");
+    let databaseCpp = await workspaceFolderSection.findItem("database.cpp");
+    await executeCtrlClickOn(databaseCpp);
+    await executeCtrlClickOn(managerCpp);
+    await releaseCtrl();
+
+    await databaseCpp.openContextMenu();
+    await (await $("aria/Create VectorCAST Environment")).click();
+
+    // making sure notifications are shown
+    await (await $("aria/Notifications")).click();
+
+    // this will timeout if VectorCAST notification does not appear, resulting in a failed test
+    const vcastNotifSourceElem = await $(
+      "aria/VectorCAST Test Explorer (Extension)",
+    );
+    const vcastNotification = await vcastNotifSourceElem.$("..");
+    await (await vcastNotification.$("aria/Yes")).click();
+
+    console.log(
+      "Waiting for clicast and waiting for environment to get processed",
+    );
+    await browser.waitUntil(
+      async () =>
+        (await (await bottomBar.openOutputView()).getText())
+          .toString()
+          .includes("Environment built Successfully"),
+      { timeout: TIMEOUT },
+    );
+
+    console.log("Finished creating vcast environment");
+    await browser.takeScreenshot();
+    await browser.saveScreenshot(
+      "info_finished_creating_vcast_environment.png",
+    );
+    // clearing all notifications
+    await (await $(".codicon-notifications-clear-all")).click();
+  });
+
+  
+  it("should open VectorCAST settings on button click", async () => {
+    await updateTestID();
+
+    console.log("closing Bottom Bar");
+    bottomBar = workbench.getBottomBar();
+    bottomBar.toggle(false);
+
+    const buttonLabel = "Open settings";
+    await clickOnButtonInTestingHeader(buttonLabel);
+
+    console.log("Verifying that VectorCAST Settings is opened");
+    const activeTab = await editorView.getActiveTab();
+    expect(await activeTab.getTitle()).toBe("Settings");
+    await browser.takeScreenshot()
+    await browser.saveScreenshot("settings_screen.png")
+    await $(
+      ".setting-item-description*=Decorate files that have coverage in the File Explorer pane",
+    );
+    await editorView.closeEditor("Settings");
+  });
+
+  it("should generate and run template test", async () => {
+    await updateTestID();
+ 
+    console.log("Opening Testing View");
+    const vcastTestingViewContent = await getViewContent("Testing");
+    let subprogram: TreeItem = undefined;
+
+    for (const vcastTestingViewSection of await vcastTestingViewContent.getSections()) {
+      if (! await vcastTestingViewSection.isExpanded())
+        await vcastTestingViewSection.expand();
+
+      for (const vcastTestingViewContentSection of await vcastTestingViewContent.getSections()) {
+        console.log(await vcastTestingViewContentSection.getTitle());
+        await vcastTestingViewContentSection.expand()
+        subprogram = await findSubprogram(
+          "manager",
+          vcastTestingViewContentSection,
+        );
+        if (subprogram) {
+          if (! await subprogram.isExpanded())
+            await subprogram.expand();
+          break;
+        }
+      }
+    }
+    if (!subprogram) {
+      throw "Subprogram 'manager' not found";
+    }
+
+    let subprogramMethod = await findSubprogramMethod(
+      subprogram,
+      "Coded Tests",
+    );
+    if (!subprogramMethod) {
+      throw "Subprogram method 'Coded Tests' not found";
+    }
+
+    if (!subprogramMethod.isExpanded()) {
+      await subprogramMethod.select();
+    }
+    
+    let ctxMenu = await subprogramMethod.openContextMenu()
+
+    await ctxMenu.select("VectorCAST");
+    let menuElem = await $("aria/Generate New Coded Test File");
+    await menuElem.click();
+
+    await $("aria/Save Code Test File")
+    for (const character of "TestFiles/manager-template.cpp") {
+      await browser.keys(character);
+    }
+    
+    await browser.keys(Key.Enter);
+    // const okButton = await $("aria/OK");
+    // await okButton.click();
+    // subprogramMethod = await findSubprogramMethod(
+    //   subprogram,
+    //   "Coded Tests",
+    // );
+    // if (!subprogramMethod.isExpanded()) {
+    //   await subprogramMethod.select();
+    // }
+    await bottomBar.openOutputView()
+    await browser.takeScreenshot()
+    await browser.saveScreenshot("after_menu.png")
+    await getTestHandle(
+      subprogram,
+      "Coded Tests",
+      "managerTests.ExampleFixtureTestCase",
+      2,
+    );
+
+    const testHandle = await getTestHandle(
+      subprogram,
+      "Coded Tests",
+      "managerTests.ExampleTestCase",
+      2,
+    );
+
+    ctxMenu = await testHandle.openContextMenu()
+    await ctxMenu.select("VectorCAST");
+    menuElem = await $("aria/Edit Coded Test");
+    await menuElem.click();
+    await browser.takeScreenshot()
+    await browser.saveScreenshot("after_edit.png")
+    await browser.waitUntil(
+      async () =>
+        (await (await editorView.getActiveTab()).getTitle()) ===
+        "manager-template.cpp",
+    );
+
+    const problemsView = await bottomBar.openProblemsView()
+    const problemMarkers = await problemsView.getAllMarkers()
+    expect(problemMarkers.length).toBe(0)
+
+    const runButton = await testHandle.getActionButton("Run Test")
+    await runButton.elem.click()
+    await browser.pause(10000)
+    
+  });
+
+  
+
+});

--- a/tests/internal/e2e/test/specs/vcast_coded_tests.test.ts
+++ b/tests/internal/e2e/test/specs/vcast_coded_tests.test.ts
@@ -116,6 +116,23 @@ describe("vTypeCheck VS Code Extension", () => {
     await (await $("aria/Set as VectorCAST Configuration File")).click()
   });
 
+  it("should enable coded testing", async () => {
+    await updateTestID();
+
+    const workbench = await browser.getWorkbench();
+    const settingsEditor = await workbench.openSettings();
+    await settingsEditor.findSetting(
+      "vectorcastTestExplorer.enableCodedTesting",
+    );
+    // only one setting in search results, so the current way of clicking is correct
+    await (await settingsEditor.checkboxSetting$).click();
+    await browser.takeScreenshot();
+    await browser.saveScreenshot(
+      "info_enabled_code_testing.png",
+    );
+    await workbench.getEditorView().closeAllEditors()
+  });
+
   it("should create VectorCAST environment", async () => {
     await updateTestID();
 
@@ -238,7 +255,7 @@ describe("vTypeCheck VS Code Extension", () => {
     let menuElem = await $("aria/Generate New Coded Test File");
     await menuElem.click();
 
-    await $("aria/Save Code Test File")
+    await (await $("aria/Save Code Test File")).click()
     for (const character of "TestFiles/manager-template.cpp") {
       await browser.keys(character);
     }

--- a/tests/internal/e2e/test/wdio.conf.ts
+++ b/tests/internal/e2e/test/wdio.conf.ts
@@ -109,11 +109,11 @@ export const config: Options.Testrunner = {
   // will be called from there.
   //
   specs: [
-    // "./**/**/vcast_testgen_bugs.test.ts",
-    // "./**/**/vcast_testgen_env.test.ts",
-    // "./**/**/vcast_testgen_unit.test.ts",
-    // "./**/**/vcast_testgen_func.test.ts",
-    // "./**/**/vcast.test.ts",
+    "./**/**/vcast_testgen_bugs.test.ts",
+    "./**/**/vcast_testgen_env.test.ts",
+    "./**/**/vcast_testgen_unit.test.ts",
+    "./**/**/vcast_testgen_func.test.ts",
+    "./**/**/vcast.test.ts",
     "./**/**/vcast_coded_tests.test.ts"
   ],
   // Patterns to exclude.

--- a/tests/internal/e2e/test/wdio.conf.ts
+++ b/tests/internal/e2e/test/wdio.conf.ts
@@ -109,11 +109,12 @@ export const config: Options.Testrunner = {
   // will be called from there.
   //
   specs: [
-    "./**/**/vcast_testgen_bugs.test.ts",
-    "./**/**/vcast_testgen_env.test.ts",
-    "./**/**/vcast_testgen_unit.test.ts",
-    "./**/**/vcast_testgen_func.test.ts",
-    "./**/**/vcast.test.ts"
+    // "./**/**/vcast_testgen_bugs.test.ts",
+    // "./**/**/vcast_testgen_env.test.ts",
+    // "./**/**/vcast_testgen_unit.test.ts",
+    // "./**/**/vcast_testgen_func.test.ts",
+    // "./**/**/vcast.test.ts",
+    "./**/**/vcast_coded_tests.test.ts"
   ],
   // Patterns to exclude.
   // exclude:
@@ -388,6 +389,9 @@ export const config: Options.Testrunner = {
     );
     const testInputEnvPath = path.join(testInputVcastTutorial, "cpp");
     await mkdir(testInputEnvPath, { recursive: true });
+    
+    const codedTestsPath = path.join(testInputVcastTutorial, "cpp", "TestsPath");
+    await mkdir(codedTestsPath , { recursive: true });
 
     const vscodeSettingsPath = path.join(testInputVcastTutorial, ".vscode");
     await mkdir(vscodeSettingsPath, { recursive: true });

--- a/tests/internal/e2e/test/wdio.conf.ts
+++ b/tests/internal/e2e/test/wdio.conf.ts
@@ -171,7 +171,7 @@ export const config: Options.Testrunner = {
         userSettings: {
           "editor.fontSize": 18,
           "terminal.integrated.fontSize": 18,
-          "window.zoomLevel": -3,
+          "window.zoomLevel": -4,
         },
         vscodeProxyOptions: {
           /**
@@ -480,6 +480,7 @@ export const config: Options.Testrunner = {
     );
     const examplesToCopy = path.join(examplesDir, "*.cpp")
 
+    const codedTestsExamplesToCopy = path.join(examplesDir, "coded_tests", "*.cpp")
     // copying didn't work with cp from fs
     if (process.platform == "win32") {
       await promisifiedExec(
@@ -492,6 +493,9 @@ export const config: Options.Testrunner = {
         `xcopy /s /i /y ${headerFilesToCopy} ${testInputEnvPath} > NUL 2> NUL`,
       );
       await promisifiedExec(
+        `xcopy /s /i /y ${codedTestsExamplesToCopy} ${codedTestsPath} > NUL 2> NUL`,
+      );
+      await promisifiedExec(
         `xcopy /s /i /y ${testInputVcastTutorial} ${path.join(
           initialWorkdir,
           "test",
@@ -502,6 +506,7 @@ export const config: Options.Testrunner = {
       await promisifiedExec(`cp ${examplesToCopy} ${testInputEnvPath}`);
       await promisifiedExec(`cp ${cppFilesToCopy} ${testInputEnvPath}`);
       await promisifiedExec(`cp ${headerFilesToCopy} ${testInputEnvPath}`);
+      await promisifiedExec(`cp ${codedTestsExamplesToCopy} ${codedTestsPath}`);
       await promisifiedExec(
         `cp -r ${testInputVcastTutorial} ${path.join(initialWorkdir, "test")}`,
       );

--- a/tests/internal/e2e/test/wdio.conf.ts
+++ b/tests/internal/e2e/test/wdio.conf.ts
@@ -390,7 +390,7 @@ export const config: Options.Testrunner = {
     const testInputEnvPath = path.join(testInputVcastTutorial, "cpp");
     await mkdir(testInputEnvPath, { recursive: true });
     
-    const codedTestsPath = path.join(testInputVcastTutorial, "cpp", "TestsPath");
+    const codedTestsPath = path.join(testInputVcastTutorial, "cpp", "TestFiles");
     await mkdir(codedTestsPath , { recursive: true });
 
     const vscodeSettingsPath = path.join(testInputVcastTutorial, ".vscode");

--- a/tests/internal/e2e/test/wdio.conf.ts
+++ b/tests/internal/e2e/test/wdio.conf.ts
@@ -403,6 +403,29 @@ export const config: Options.Testrunner = {
     else createLaunchJson = `touch ${launchJsonPath}`;
     await promisifiedExec(createLaunchJson);
     
+    const pathTovUnitInclude = path.join(vectorcastDir, "vunit", "include")
+    const c_cpp_properties = {
+      configurations: [
+          {
+              "name": "Linux",
+              "includePath": [
+                  "${workspaceFolder}/**",
+                  `${pathTovUnitInclude}`  
+              ],
+              "defines": [],
+              "compilerPath": "/usr/bin/clang",
+              "cStandard": "c17",
+              "cppStandard": "c++14",
+              "intelliSenseMode": "linux-clang-x64"
+          }
+      ],
+      version: 4
+    }
+
+    const c_cpp_properties_JSON = JSON.stringify(c_cpp_properties, null, 4);
+    const c_cpp_properties_JSONPath = path.join(vscodeSettingsPath, "c_cpp_properties.json");
+    await writeFile(c_cpp_properties_JSONPath, c_cpp_properties_JSON);
+
     const envFile = `ENVIRO.NEW
     ENVIRO.NAME: DATABASE-MANAGER-test
     ENVIRO.COVERAGE_TYPE: Statement


### PR DESCRIPTION
Added E2E tests for:
- Enabling coded tests
- Generating and running a template test
 - Running from test tree
 - Checking there are no error markers
- Preparation for debugging
- Deleting coded tests
- Adding an existing coded tests file with and without compile errors
  - Checking how compile errors are shown
- Coverage percentage shown on the Status Bar
- Creating and running a new coded test with and without compile errors