### PR TITLE
Fix for issue #76, nested relative paths for unit test location

### DIFF
--- a/src/vcastTestInterface.ts
+++ b/src/vcastTestInterface.ts
@@ -656,9 +656,9 @@ function configureWorkspaceAndBuildEnviro(
           try {
             fs.mkdirSync(unitTestLocation, { recursive: true });
             commonNewEnvironmentStuff(fileList, unitTestLocation);
-          } catch (error) {
+          } catch (error:any) {
             vscode.window.showErrorMessage(
-              `Error creating directory: ${unitTestLocation}, update the 'Unit Test Location' option to a valid value`
+              `Error creating directory: ${unitTestLocation} [${error.message}].  Update the 'Unit Test Location' option to a valid value`
             );
             vectorMessage("Error creating directory: " + unitTestLocation);
             showSettings();

--- a/src/vcastTestInterface.ts
+++ b/src/vcastTestInterface.ts
@@ -653,8 +653,16 @@ function configureWorkspaceAndBuildEnviro(
       .showInformationMessage(message, "Yes", "No")
       .then((answer) => {
         if (answer === "Yes") {
-          fs.mkdirSync(unitTestLocation);
-          commonNewEnvironmentStuff(fileList, unitTestLocation);
+          try {
+            fs.mkdirSync(unitTestLocation, { recursive: true });
+            commonNewEnvironmentStuff(fileList, unitTestLocation);
+          } catch (error) {
+            vscode.window.showErrorMessage(
+              `Error creating directory: ${unitTestLocation}, update the 'Unit Test Location' option to a valid value`
+            );
+            vectorMessage("Error creating directory: " + unitTestLocation);
+            showSettings();
+          }
         } else {
           vscode.window.showWarningMessage(
             `Please create the unit test directory: '${unitTestLocation}', or update the 'Unit Test Location' option`


### PR DESCRIPTION
There are two cases handled in the fix
- An illegal value for the path, like: "./unitTests/****"
- A valid value with nested syntax like: "./unittests/a/b/c

@Zbigor both should be tested