### PR TITLE
Fix colour scheme for stdout/stderr from driver (`<pre>`)

### DIFF
--- a/src/reporting.ts
+++ b/src/reporting.ts
@@ -82,6 +82,12 @@ tr:hover {
 .warning:hover, .bg-warning:hover {
     background-color: var(--vscode-testing-iconQueued) !important;
 }
+
+pre {
+  border:1px solid var(--vscode-editorGroup-border);
+  background-color:var(--vscode-editorGroup-border);
+  color: var(--vscode-foreground);
+}
 </style>`;
         returnText += line;
         skipping = false;


### PR DESCRIPTION
This PR fixes the CSS styling for `<pre>` blocks, which are used in reports for stdout/stderr from VectorCAST's harness.