### PR TITLE
Added support for JSON-C formatted configuration files

### DIFF
--- a/package.json
+++ b/package.json
@@ -569,7 +569,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run esbuild-base -- --minify && npm run esbuild-server -- --minify",
-    "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",
+    "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --external:jsonc-parser --format=cjs --platform=node",
     "esbuild-server": "esbuild ./server/server.ts --bundle --outfile=out/server.js --external:vscode --format=cjs --platform=node",
     "esbuild-watch": "npm-run-all --parallel esbuild-base esbuild-server -- --sourcemap --watch",
     "esbuild": "npm run esbuild-base -- --sourcemap && npm run esbuild-server -- --sourcemap",
@@ -606,7 +606,8 @@
     "npm-run-all": "^4.1.5",
     "tslib": "^1.9.3",
     "vscode-languageclient": "^5.2.1",
-    "vscode-languageserver": "^5.2.1"
+    "vscode-languageserver": "^5.2.1",
+    "jsonc-parser": "^3.2.1"
   },
   "extensionDependencies": [],
   "engines": {

--- a/src/testPane.ts
+++ b/src/testPane.ts
@@ -571,9 +571,9 @@ function launchConfigExists(launchJsonPath: string): boolean {
   // this will check if launch.json has
   // the "VectorCAST Harness Debug" configuration defined
   let returnValue = false;
-  const existingJSON: any = loadLaunchFile(launchJsonPath);
-  if (existingJSON.configurations) {
-    for (const existingConfig of existingJSON.configurations) {
+  const existingJSONdata: any = loadLaunchFile(launchJsonPath);
+  if (existingJSONdata) {
+    for (const existingConfig of existingJSONdata.jsonData.configurations) {
       if (existingConfig.name === vectorcastLaunchConfigName) {
         returnValue = true;
         launchFilesWithVectorCASTConfig.set(launchJsonPath, true);
@@ -719,11 +719,16 @@ async function debugNode(
 
         createEmptyLaunchConfigFile(ourWorkspace, launchJsonPath);
         addLaunchConfiguration(launchJsonUri);
-      } else {
+      } 
+      else {
         debugConfigurationFound = launchConfigExists(launchJsonPath);
-        if (!debugConfigurationFound) addLaunchConfiguration(launchJsonUri);
+        if (!debugConfigurationFound) {
+          addLaunchConfiguration(launchJsonUri);
+        }
       }
 
+      // this flag means that the launch file already had a vectorcast debug configuration
+      // if we just added it we want to give the user a chance to review before we debug
       if (debugConfigurationFound) {
         vectorMessage(
           `Preparing to debug test ${getTestNameFromID(node.id)} ... `

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 
 // TBD TODAY - import
-import * as jsonc from "jsonc-parser"
+//import * as jsonc from "jsonc-parser"
 
 import { Uri } from "vscode";
 
@@ -19,7 +19,8 @@ const vPythonName = "vpython";
 const vpythonFromPath = which.sync(vPythonName, { nothrow: true })
 export let vPythonCommandToUse: string | undefined = undefined;
 
-export const jsoncParseOptions:jsonc.ParseOptions = { allowTrailingComma: true, disallowComments: false, allowEmptyContent:false };
+// TBD TODAY - parseOptions
+//export const jsoncParseOptions:jsonc.ParseOptions = { allowTrailingComma: true, disallowComments: false, allowEmptyContent:false };
 
 
 // The testInterface is delivered in the .vsix

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -19,9 +19,8 @@ const vPythonName = "vpython";
 const vpythonFromPath = which.sync(vPythonName, { nothrow: true })
 export let vPythonCommandToUse: string | undefined = undefined;
 
-// TBD TODAY - parseOptions
+// options used for reading json-c files
 export const jsoncParseOptions:jsonc.ParseOptions = { allowTrailingComma: true, disallowComments: false, allowEmptyContent:false };
-
 
 // The testInterface is delivered in the .vsix
 // in the sub-directory "python"
@@ -164,12 +163,13 @@ export function loadLaunchFile(jsonPath: string): any {
   // if we cannot read the file
   let existingJSON: any;
   try {
-    // TBD TODAY - Requires json-c parsing to handle comments etc.
-    // existingJSON = jsonc.parse(fs.readFileSync(jsonPath), [], jsoncParseOptions);
-    existingJSON = jsonc.parse('{"version": "1.0" // hello}', [], jsoncParseOptions);
-    existingJSON = JSON.parse(fs.readFileSync(jsonPath).toString());
+    // Requires json-c parsing to handle comments etc.
+    const existingContents = fs.readFileSync (jsonPath).toString();
+    var parseErrors: jsonc.ParseError[] = [];  // not using programatically, for debug only
+    existingJSON = jsonc.parse(existingContents, parseErrors, jsoncParseOptions);
   } catch {
-    // if file is empty ...
+    // if any error occurs on reading, don't changne the file?
+    vscode.window.showErrorMessage(`Could not load the existing ${path.basename (jsonPath)}, check for syntax errors`);
     existingJSON = { configurations: [] };
   }
   return existingJSON;
@@ -222,12 +222,12 @@ export function addSettingsFileFilter(fileUri: Uri) {
   const filePath = fileUri.fsPath;
   let existingJSON;
   try {
-    // TBD TODAY - Requires json-c parsing to handle comments etc.
-    // existingJSON = jsonc.parse(fs.readFileSync(filePath), [], jsoncParseOptions);
-    existingJSON = jsonc.parse('{"version": "1.0" // hello}', [], jsoncParseOptions);
-    existingJSON = JSON.parse(fs.readFileSync(filePath));
+    // Requires json-c parsing to handle comments etc.
+    const existingContents = fs.readFileSync (filePath).toString();
+    var parseErrors: jsonc.ParseError[] = [];  // not using programatically, for debug only
+    existingJSON = jsonc.parse(existingContents, parseErrors, jsoncParseOptions);
   } catch {
-    // if the file is empty ...
+    vscode.window.showErrorMessage(`Could not load the existing ${path.basename (filePath)}, check for syntax errors`);
     existingJSON = {};
   }
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 
-// TBD TODAY - import
+// needed for parsing json files with comments
 import * as jsonc from "jsonc-parser"
 
 import { Uri } from "vscode";

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 
 // TBD TODAY - import
-//import * as jsonc from "jsonc-parser"
+import * as jsonc from "jsonc-parser"
 
 import { Uri } from "vscode";
 
@@ -20,7 +20,7 @@ const vpythonFromPath = which.sync(vPythonName, { nothrow: true })
 export let vPythonCommandToUse: string | undefined = undefined;
 
 // TBD TODAY - parseOptions
-//export const jsoncParseOptions:jsonc.ParseOptions = { allowTrailingComma: true, disallowComments: false, allowEmptyContent:false };
+export const jsoncParseOptions:jsonc.ParseOptions = { allowTrailingComma: true, disallowComments: false, allowEmptyContent:false };
 
 
 // The testInterface is delivered in the .vsix
@@ -166,6 +166,7 @@ export function loadLaunchFile(jsonPath: string): any {
   try {
     // TBD TODAY - Requires json-c parsing to handle comments etc.
     // existingJSON = jsonc.parse(fs.readFileSync(jsonPath), [], jsoncParseOptions);
+    existingJSON = jsonc.parse('{"version": "1.0" // hello}', [], jsoncParseOptions);
     existingJSON = JSON.parse(fs.readFileSync(jsonPath).toString());
   } catch {
     // if file is empty ...
@@ -223,6 +224,7 @@ export function addSettingsFileFilter(fileUri: Uri) {
   try {
     // TBD TODAY - Requires json-c parsing to handle comments etc.
     // existingJSON = jsonc.parse(fs.readFileSync(filePath), [], jsoncParseOptions);
+    existingJSON = jsonc.parse('{"version": "1.0" // hello}', [], jsoncParseOptions);
     existingJSON = JSON.parse(fs.readFileSync(filePath));
   } catch {
     // if the file is empty ...

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -166,6 +166,7 @@ export function loadLaunchFile(jsonPath: string): any {
     // Requires json-c parsing to handle comments etc.
     const existingContents = fs.readFileSync (jsonPath).toString();
     var parseErrors: jsonc.ParseError[] = [];  // not using programatically, for debug only
+    // note that jsonc.parse returns "real json" without the comments
     existingJSON = jsonc.parse(existingContents, parseErrors, jsoncParseOptions);
   } catch {
     // if any error occurs on reading, don't changne the file?
@@ -225,6 +226,7 @@ export function addSettingsFileFilter(fileUri: Uri) {
     // Requires json-c parsing to handle comments etc.
     const existingContents = fs.readFileSync (filePath).toString();
     var parseErrors: jsonc.ParseError[] = [];  // not using programatically, for debug only
+    // note that jsonc.parse returns "real json" without the comments
     existingJSON = jsonc.parse(existingContents, parseErrors, jsoncParseOptions);
   } catch {
     vscode.window.showErrorMessage(`Could not load the existing ${path.basename (filePath)}, check for syntax errors`);

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -157,23 +157,28 @@ export function getChecksumCommand() {
   return globalCheckSumCommand;
 }
 
-export function loadLaunchFile(jsonPath: string): any {
+export interface jsonDataType {
+  jsonData:any;
+  jsonDataAsString:string;
+}
+
+export function loadLaunchFile(jsonPath: string): jsonDataType|undefined {
+
   // this function takes the path to a launch.json
   // and returns the contents, or an empty list of configurations
   // if we cannot read the file
-  let existingJSON: any;
-  try {
-    // Requires json-c parsing to handle comments etc.
-    const existingContents = fs.readFileSync (jsonPath).toString();
-    var parseErrors: jsonc.ParseError[] = [];  // not using programatically, for debug only
-    // note that jsonc.parse returns "real json" without the comments
-    existingJSON = jsonc.parse(existingContents, parseErrors, jsoncParseOptions);
-  } catch {
-    // if any error occurs on reading, don't changne the file?
-    vscode.window.showErrorMessage(`Could not load the existing ${path.basename (jsonPath)}, check for syntax errors`);
-    existingJSON = { configurations: [] };
+  let returnValue:jsonDataType|undefined = undefined;
+  
+  // Requires json-c parsing to handle comments etc.
+  const existingContents = fs.readFileSync (jsonPath).toString();
+  var parseErrors: jsonc.ParseError[] = [];  // not using programatically, for debug only
+  // note that jsonc.parse returns "real json" without the comments
+  const existingJSONdata = jsonc.parse(existingContents, parseErrors, jsoncParseOptions);
+  
+  if (existingJSONdata) {
+    returnValue = { jsonData:existingJSONdata , jsonDataAsString: existingContents };
   }
-  return existingJSON;
+  return returnValue;
 }
 
 export function addLaunchConfiguration(fileUri: Uri) {
@@ -181,61 +186,76 @@ export function addLaunchConfiguration(fileUri: Uri) {
   // launch.json file that the user right clicks on
 
   const jsonPath = fileUri.fsPath;
-  const existingJSON: any = loadLaunchFile(jsonPath);
-
-  // Remember that the vectorJSON data has the "configurations" level which is an array
+  const existingLaunchData:jsonDataType|undefined = loadLaunchFile(jsonPath);
+  
   const vectorJSON = JSON.parse(
     fs.readFileSync(
       path.join(globalPathToSupportFiles, "vcastLaunchTemplate.json")
     )
   );
 
-  const vectorConfiguration = vectorJSON.configurations[0];
+  // if we have a well formatted launch file with an array of configurations ...
+  if (existingLaunchData && existingLaunchData.jsonData.configurations && existingLaunchData.jsonData.configurations.length > 0) {
 
-  // now loop through launch.json to make sure it does not already have the vector config
-  let existingConfigFound = false;
+      // Remember that the vectorJSON data has the "configurations" level which is an array
+    const vectorConfiguration = vectorJSON.configurations[0];
 
-  if (existingJSON.configurations)
-    for (const existingConfig of existingJSON.configurations) {
+    // now loop through launch.json to make sure it does not already have the vector config
+    let needToAddVectorLaunchConfig = true;
+
+    for (const existingConfig of existingLaunchData.jsonData.configurations) {
       if (existingConfig.name == vectorConfiguration.name) {
-        existingConfigFound = true;
+        vscode.window.showInformationMessage(
+          `File: ${jsonPath}, already contains a ${vectorConfiguration.name} configuration`
+        );
+        needToAddVectorLaunchConfig = false;
         break;
       }
     }
-  else {
-    // if file does not have "configuration" section ...
-    existingJSON.configurations = [];
+    if (needToAddVectorLaunchConfig) {
+      const whereToInsert = existingLaunchData.jsonData.configurations.length;
+      let jsonDataAsString = existingLaunchData.jsonDataAsString;
+      const jsoncEdits  = 
+        jsonc.modify(
+            jsonDataAsString, 
+            ["configurations", whereToInsert], 
+            vectorConfiguration, 
+            { formattingOptions: { tabSize: 4, insertSpaces: true }, isArrayInsertion:true });
+      jsonDataAsString = jsonc.applyEdits (jsonDataAsString, jsoncEdits);
+      fs.writeFileSync(jsonPath, jsonDataAsString);
+    }
   }
-
-  if (existingConfigFound) {
-    vscode.window.showInformationMessage(
-      `File: ${jsonPath}, already contains a ${vectorConfiguration.name} configuration`
-    );
-  } else {
-    existingJSON.configurations.push(vectorConfiguration);
-    // TBD TODAY - Need to replace with the json-c editing stuff
-    fs.writeFileSync(jsonPath, JSON.stringify(existingJSON, null, "\t"));
-  
+  else {
+    // if the existing file is emty or does not contain a "configurations" section, 
+    // simply insert the vector config.  This allows the user to start with an empty file
+    fs.writeFileSync (jsonPath, JSON.stringify(vectorJSON, null, 4));
   }
 }
 
+const filesExcludeString = "files.exclude";
 export function addSettingsFileFilter(fileUri: Uri) {
+
   const filePath = fileUri.fsPath;
   let existingJSON;
+  let existingJSONasString:string;
+
   try {
     // Requires json-c parsing to handle comments etc.
-    const existingContents = fs.readFileSync (filePath).toString();
+    existingJSONasString = fs.readFileSync (filePath).toString();
     var parseErrors: jsonc.ParseError[] = [];  // not using programatically, for debug only
     // note that jsonc.parse returns "real json" without the comments
-    existingJSON = jsonc.parse(existingContents, parseErrors, jsoncParseOptions);
-  } catch {
+    existingJSON = jsonc.parse(existingJSONasString, parseErrors, jsoncParseOptions);
+  } 
+  catch {
     vscode.window.showErrorMessage(`Could not load the existing ${path.basename (filePath)}, check for syntax errors`);
-    existingJSON = {};
+    return;
   }
 
-  // if the file is missing the files.exclude section
-  if (!existingJSON.hasOwnProperty("files.exclude")) {
-    existingJSON["files.exclude"] = {};
+  // if the file does not have a "files.exclude" section, add one
+  if (!existingJSON.hasOwnProperty(filesExcludeString)) {
+    // we don't need to modify the existing jsonAsString 
+    // because it will do the insert of a new section for us
+    existingJSON[filesExcludeString] = {};
   }
 
   // Remember that the vectorJSON data has the "configurations" level which is an array
@@ -244,17 +264,24 @@ export function addSettingsFileFilter(fileUri: Uri) {
   );
 
   // now check if the vector filters are already in the files.exclude object
-  if (existingJSON["files.exclude"].hasOwnProperty("vectorcast-filter-start")) {
+  if (existingJSON[filesExcludeString].hasOwnProperty("vectorcast-filter-start")) {
     vscode.window.showInformationMessage(
       `File: ${filePath}, already contains the VectorCAST exclude patterns`
     );
-  } else {
-    existingJSON["files.exclude"] = Object.assign(
+  } 
+  else {
+    const mergedExcludeList = Object.assign(
       existingJSON["files.exclude"],
-      vectorJSON["files.exclude"]
-    );
-    // TBD TODAY - Need to replace with the json-c editing stuff
-    fs.writeFileSync(filePath, JSON.stringify(existingJSON, null, "\t"));
+      vectorJSON["files.exclude"]);
+    const jsoncEdits = 
+      jsonc.modify(
+        existingJSONasString, 
+        [filesExcludeString], 
+        mergedExcludeList,
+        { formattingOptions: { tabSize: 4, insertSpaces: true } });
+    existingJSONasString = jsonc.applyEdits (existingJSONasString, jsoncEdits);
+
+    fs.writeFileSync(filePath, existingJSONasString);
   }
 }
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,4 +1,8 @@
 import * as vscode from "vscode";
+
+// TBD TODAY - import
+import * as jsonc from "jsonc-parser"
+
 import { Uri } from "vscode";
 
 import { clicastCommandToUse, initializeCodedTestSupport, initializeVcastUtilities } from "./vcastUtilities";
@@ -15,6 +19,7 @@ const vPythonName = "vpython";
 const vpythonFromPath = which.sync(vPythonName, { nothrow: true })
 export let vPythonCommandToUse: string | undefined = undefined;
 
+export const jsoncParseOptions:jsonc.ParseOptions = { allowTrailingComma: true, disallowComments: false, allowEmptyContent:false };
 
 
 // The testInterface is delivered in the .vsix
@@ -158,7 +163,9 @@ export function loadLaunchFile(jsonPath: string): any {
   // if we cannot read the file
   let existingJSON: any;
   try {
-    existingJSON = JSON.parse(fs.readFileSync(jsonPath));
+    // TBD TODAY - Requires json-c parsing to handle comments etc.
+    // existingJSON = jsonc.parse(fs.readFileSync(jsonPath), [], jsoncParseOptions);
+    existingJSON = JSON.parse(fs.readFileSync(jsonPath).toString());
   } catch {
     // if file is empty ...
     existingJSON = { configurations: [] };
@@ -203,6 +210,7 @@ export function addLaunchConfiguration(fileUri: Uri) {
     );
   } else {
     existingJSON.configurations.push(vectorConfiguration);
+    // TBD TODAY - Need to replace with the json-c editing stuff
     fs.writeFileSync(jsonPath, JSON.stringify(existingJSON, null, "\t"));
   
   }
@@ -212,6 +220,8 @@ export function addSettingsFileFilter(fileUri: Uri) {
   const filePath = fileUri.fsPath;
   let existingJSON;
   try {
+    // TBD TODAY - Requires json-c parsing to handle comments etc.
+    // existingJSON = jsonc.parse(fs.readFileSync(filePath), [], jsoncParseOptions);
     existingJSON = JSON.parse(fs.readFileSync(filePath));
   } catch {
     // if the file is empty ...
@@ -223,7 +233,7 @@ export function addSettingsFileFilter(fileUri: Uri) {
     existingJSON["files.exclude"] = {};
   }
 
-  // REmember that the vectorJSON data has the "configurations" level which is an array
+  // Remember that the vectorJSON data has the "configurations" level which is an array
   const vectorJSON = JSON.parse(
     fs.readFileSync(path.join(globalPathToSupportFiles, "vcastSettings.json"))
   );
@@ -238,6 +248,7 @@ export function addSettingsFileFilter(fileUri: Uri) {
       existingJSON["files.exclude"],
       vectorJSON["files.exclude"]
     );
+    // TBD TODAY - Need to replace with the json-c editing stuff
     fs.writeFileSync(filePath, JSON.stringify(existingJSON, null, "\t"));
   }
 }

--- a/src/vcastUtilities.ts
+++ b/src/vcastUtilities.ts
@@ -30,8 +30,6 @@ import {
   getClicastArgsFromTestNode,
   getClicastArgsFromTestNodeAsList,
 } from "./vcastTestInterface";
-import { writeFileSync } from "fs";
-
 
 const fs = require("fs");
 const os = require("os");
@@ -163,54 +161,69 @@ export function addIncludePath (fileUri: vscode.Uri) {
   // I'm handling a few error cases here without going crazy
   let statusMessages:string[] = [];
 
-  // read the existing file contents
   let existingJSON: any;
-  try {
-    // Requires json-c parsing to handle comments etc.
-    const existingContents = fs.readFileSync (fileUri.fsPath).toString();
-    var parseErrors: jsonc.ParseError[] = [];  // not using programatically, for debug only
-    // note that jsonc.parse returns "real json" without the comments
-    existingJSON = jsonc.parse(existingContents, parseErrors, jsoncParseOptions);
-    if (existingJSON.configurations.length == 0) {
-      statusMessages.push (`{configurationFile} file has no existing configurations, creating a 'vcast' configuraiton.  `); 
-      existingJSON.configurations.push ({name: "vcast", includePath: []});
-    }
-  } catch {
-    // if there is some sort of parse error with the existing file don't change it
-    vscode.window.showErrorMessage(`Exception parsing {configurationFile} file, no changes made.  Check for syntax errors.  `);
+  let existingJSONasString: string;
+  
+  // Requires json-c parsing to handle comments etc.
+  existingJSONasString  = fs.readFileSync (fileUri.fsPath).toString();
+  var parseErrors: jsonc.ParseError[] = [];  // not using programatically, for debug only
+  // note that jsonc.parse returns "real json" without the comments
+  existingJSON = jsonc.parse(existingJSONasString, parseErrors, jsoncParseOptions);
+
+  if (existingJSON && existingJSON.configurations && existingJSON.configurations.length > 0) {
+    const numberOfCofigurations = existingJSON.configurations.length;
+    statusMessages.push (`{configurationFile} file has ${numberOfCofigurations} configurations ... `); 
+  }
+  else {
+    statusMessages.push (`{configurationFile} file has no existing configurations, please add a configuration.   `); 
+    vscode.window.showErrorMessage(statusMessages.join ("\n"));
     return;
   }
-
+  
   // when we get here we should always have a configurations array
-  // but we might now have an includePath, so add it if its missing
+  // but we might not have an includePath, so add it if its missing
   
   let configName = existingJSON.configurations[0].name;
   if (existingJSON.configurations[0].includePath == undefined) {
     statusMessages.push (`Configuration: "${configName}" is missing an includePath list, adding.  `); 
+    // we keep the existing JSON up to date to make the logic below simpler
     existingJSON.configurations[0].includePath = [];
   }
 
-  let includePath = existingJSON.configurations[0].includePath;
-  if (includePath.includes(globalIncludePath)) {
+  let includePathList = existingJSON.configurations[0].includePath;
+  let whereToInsert = existingJSON.configurations[0].includePath.length;
+  if (includePathList.includes(globalIncludePath)) {
     statusMessages.push (`Configuration: "${configName}" already contains the correct include path.  `); 
   }
   else {
     // if the user updated versions of VectorCAST, we might have an "old" include path that needs to be removed
-    const indexToRemove = includePath.findIndex ( (element:string) => element.includes("/vunit/include"));
+    const indexToRemove = includePathList.findIndex ( (element:string) => element.includes("/vunit/include"));
     if (indexToRemove >= 0) {
-      const oldPath = includePath[indexToRemove];
-      includePath.splice (indexToRemove, 1);
+      const oldPath = includePathList[indexToRemove];
+      const jsoncEdits = 
+        jsonc.modify(
+          existingJSONasString, 
+          ["configurations",0,"includePath",indexToRemove], 
+          undefined, 
+          { formattingOptions: { tabSize: 4, insertSpaces: true } });
+      existingJSONasString = jsonc.applyEdits (existingJSONasString, jsoncEdits);
       statusMessages.push (`Removed: ${oldPath} from configuration: "${configName}".  `);
     }
-    includePath.push (globalIncludePath)
+    
+    const jsoncEdits = 
+      jsonc.modify(
+        existingJSONasString, 
+        ["configurations",0,"includePath",whereToInsert],
+        globalIncludePath,
+        { formattingOptions: { tabSize: 4, insertSpaces: true } });
+    existingJSONasString = jsonc.applyEdits (existingJSONasString, jsoncEdits);
     statusMessages.push (`Added: ${globalIncludePath} to configuration: "${configName}".  `); 
   }
 
   vscode.window.showInformationMessage(statusMessages.join ("\n"));
 
   // we unconditionally write rather than tracking if we changed anything
-  // TBD TODAY - Need to replace with the json-c editing stuff
-  writeFileSync (fileUri.fsPath, JSON.stringify(existingJSON, null, 4));
+  fs.writeFileSync(fileUri.fsPath, existingJSONasString);
 
 }
 

--- a/src/vcastUtilities.ts
+++ b/src/vcastUtilities.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 
-// TBD TODAY - import
+// needed for parsing json files with comments
 import * as jsonc from "jsonc-parser";
 
 import {

--- a/src/vcastUtilities.ts
+++ b/src/vcastUtilities.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 
 // TBD TODAY - import
-// import * as jsonc from "jsonc-parser";
+import * as jsonc from "jsonc-parser";
 
 import {
   openMessagePane,
@@ -21,8 +21,7 @@ import {
   commandStatusType,
   executeCommandSync,
   exeFilename,
-// TBD TODAY
-//  jsoncParseOptions,
+  jsoncParseOptions,
   openFileWithLineSelected,
   processExceptionFromExecuteCommand,
 } from "./utilities";
@@ -169,6 +168,7 @@ export function addIncludePath (fileUri: vscode.Uri) {
   try {
     // TBD TODAY - Requires json-c parsing to handle comments etc.
     // existingJSON = jsonc.parse(fs.readFileSync(fileUri.fsPath), [], jsoncParseOptions);
+    existingJSON = jsonc.parse('{"version": "1.0" // hello}', [], jsoncParseOptions);
     existingJSON = JSON.parse(fs.readFileSync(fileUri.fsPath).toString());
     if (existingJSON.configurations.length == 0) {
       statusMessages.push (`{configurationFile} file has no existing configurations, creating a 'vcast' configuraiton.  `); 

--- a/src/vcastUtilities.ts
+++ b/src/vcastUtilities.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 
 // TBD TODAY - import
-import * as jsonc from "jsonc-parser";
+// import * as jsonc from "jsonc-parser";
 
 import {
   openMessagePane,
@@ -21,7 +21,8 @@ import {
   commandStatusType,
   executeCommandSync,
   exeFilename,
-  jsoncParseOptions,
+// TBD TODAY
+//  jsoncParseOptions,
   openFileWithLineSelected,
   processExceptionFromExecuteCommand,
 } from "./utilities";

--- a/src/vcastUtilities.ts
+++ b/src/vcastUtilities.ts
@@ -169,6 +169,7 @@ export function addIncludePath (fileUri: vscode.Uri) {
     // Requires json-c parsing to handle comments etc.
     const existingContents = fs.readFileSync (fileUri.fsPath).toString();
     var parseErrors: jsonc.ParseError[] = [];  // not using programatically, for debug only
+    // note that jsonc.parse returns "real json" without the comments
     existingJSON = jsonc.parse(existingContents, parseErrors, jsoncParseOptions);
     if (existingJSON.configurations.length == 0) {
       statusMessages.push (`{configurationFile} file has no existing configurations, creating a 'vcast' configuraiton.  `); 

--- a/src/vcastUtilities.ts
+++ b/src/vcastUtilities.ts
@@ -166,10 +166,10 @@ export function addIncludePath (fileUri: vscode.Uri) {
   // read the existing file contents
   let existingJSON: any;
   try {
-    // TBD TODAY - Requires json-c parsing to handle comments etc.
-    // existingJSON = jsonc.parse(fs.readFileSync(fileUri.fsPath), [], jsoncParseOptions);
-    existingJSON = jsonc.parse('{"version": "1.0" // hello}', [], jsoncParseOptions);
-    existingJSON = JSON.parse(fs.readFileSync(fileUri.fsPath).toString());
+    // Requires json-c parsing to handle comments etc.
+    const existingContents = fs.readFileSync (fileUri.fsPath).toString();
+    var parseErrors: jsonc.ParseError[] = [];  // not using programatically, for debug only
+    existingJSON = jsonc.parse(existingContents, parseErrors, jsoncParseOptions);
     if (existingJSON.configurations.length == 0) {
       statusMessages.push (`{configurationFile} file has no existing configurations, creating a 'vcast' configuraiton.  `); 
       existingJSON.configurations.push ({name: "vcast", includePath: []});

--- a/src/vcastUtilities.ts
+++ b/src/vcastUtilities.ts
@@ -1,5 +1,8 @@
 import * as vscode from "vscode";
 
+// TBD TODAY - import
+import * as jsonc from "jsonc-parser";
+
 import {
   openMessagePane,
   vectorMessage,
@@ -18,6 +21,7 @@ import {
   commandStatusType,
   executeCommandSync,
   exeFilename,
+  jsoncParseOptions,
   openFileWithLineSelected,
   processExceptionFromExecuteCommand,
 } from "./utilities";
@@ -162,7 +166,9 @@ export function addIncludePath (fileUri: vscode.Uri) {
   // read the existing file contents
   let existingJSON: any;
   try {
-    existingJSON = JSON.parse(fs.readFileSync(fileUri.fsPath));
+    // TBD TODAY - Requires json-c parsing to handle comments etc.
+    // existingJSON = jsonc.parse(fs.readFileSync(fileUri.fsPath), [], jsoncParseOptions);
+    existingJSON = JSON.parse(fs.readFileSync(fileUri.fsPath).toString());
     if (existingJSON.configurations.length == 0) {
       statusMessages.push (`{configurationFile} file has no existing configurations, creating a 'vcast' configuraiton.  `); 
       existingJSON.configurations.push ({name: "vcast", includePath: []});
@@ -201,6 +207,7 @@ export function addIncludePath (fileUri: vscode.Uri) {
   vscode.window.showInformationMessage(statusMessages.join ("\n"));
 
   // we unconditionally write rather than tracking if we changed anything
+  // TBD TODAY - Need to replace with the json-c editing stuff
   writeFileSync (fileUri.fsPath, JSON.stringify(existingJSON, null, 4));
 
 }


### PR DESCRIPTION
This PR fixes issue: #78

Updated the processing of launch.json, c_cpp_properties.json, and settings.json to use jsonc-parser which supports reading and writing json-c files.
