### PR TITLE
Add coded tests input file

### DIFF
--- a/tests/internal/e2e/test/examples/coded_tests/manager-Tests.cpp
+++ b/tests/internal/e2e/test/examples/coded_tests/manager-Tests.cpp
@@ -1,0 +1,53 @@
+#include <vunit/vunit.h>
+#include "manager.h"
+#include "cpptypes.h"
+
+namespace
+{
+class managerFixture : public ::vunit::Fixture
+{
+protected:
+  void SetUp(void) override {
+    // Setup code goes here.
+  }
+
+  void TearDown(void) override {
+    // Cleanup code goes here.
+  }
+};
+} // namespace
+
+VTEST(managerTests, ExampleTestCase) {
+  VASSERT(true);
+}
+
+VTEST_F(managerTests, ExampleFixtureTestCase, managerFixture) {
+  VASSERT_EQ(1+1, 2);
+}
+
+
+VTEST(managerTests, realTest) {
+    int localSeat = 1;
+    int localTable = 1;
+    OrderType localOrder;
+
+    localOrder.Entree = Lobster;
+
+    Manager manager;
+    manager.PlaceOrder(localTable, localSeat, localOrder);
+
+    VASSERT_EQ(10, manager.GetCheckTotal(localTable));
+}
+
+VTEST(managerTests, fakeTest) {
+
+}
+
+VTEST(managerTests, compileErrorTest) {
+
+      VASSERT_EQ(10, 20);
+      VASSERT_EQ(10, 10);
+
+      compile-error-here
+
+}


### PR DESCRIPTION
This test was seemingly missing when the E2E tests for coded tests got merged, which meant no tests run.

This PR restores that file, allowing the tests to run.