### PR TITLE
Gha support for large files

### DIFF
--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - gha_support_for_large_files   # TODO tmp
   pull_request:
     branches:
       - main

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - gha_support_for_large_files   # TODO tmp
   pull_request:
     branches:
       - main
@@ -196,6 +197,7 @@ jobs:
         if: always()
         with:
           check_name: "E2e Test results - Vcast 23"
+          large_files: true
           files: |
             ./tests/internal/e2e/test_results/*.xml
 
@@ -314,6 +316,7 @@ jobs:
         if: always()
         with:
           check_name: "E2e Test results - Vcast 24"
+          large_files: true
           files: |
             ./tests/internal/e2e/test_results/*.xml
 


### PR DESCRIPTION
The GH Actions plugin "EnricoMi/publish-unit-test-result-action" sometimes crashes when the input files are too big to handle. We are adding large file support, setting the `large_files` parameter to `true`.