### PR TITLE
Improvements to GitHub Actions

### DIFF
--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -1,5 +1,5 @@
 name: Vector Vscode Vcast Tests
-run-name: ${{ github.actor }} running tests
+run-name: ${{ github.ref_name }} is being tested
 on:
   push:
     branches:
@@ -221,9 +221,10 @@ jobs:
           if [ $count != 0 ] ; then
             cd tests/internal/e2e
             tar -cvzf e2e_vcast23_screenshots.tar.gz *.png > /dev/null
-            curl -H "X-JFrog-Art-Api:${{ secrets.ARTIFACTORY_TOKEN }}" -X PUT $ARTIFACTORY_URL/e2e_vcast23_screenshots.tar.gz -T e2e_vcast23_screenshots.tar.gz
+            URL="$BASE_ARTIFACTORY_URL/e2e_vcast23_screenshots/"
+            curl -H "X-Explode-Archive: true" -H "X-JFrog-Art-Api:${{ secrets.ARTIFACTORY_TOKEN }}" -X PUT $URL -T e2e_vcast23_screenshots.tar.gz
             cd ../../..
-            echo "[Screenshots]($ARTIFACTORY_URL/e2e_vcast23_screenshots.tar.gz)" >> $GITHUB_STEP_SUMMARY
+            echo "[Screenshots]($URL)" >> $GITHUB_STEP_SUMMARY
           fi
 
       - name: Save dependencies - node
@@ -340,9 +341,10 @@ jobs:
           if [ $count != 0 ] ; then
             cd tests/internal/e2e
             tar -cvzf e2e_vcast24_screenshots.tar.gz *.png > /dev/null
-            curl -H "X-JFrog-Art-Api:${{ secrets.ARTIFACTORY_TOKEN }}" -X PUT $ARTIFACTORY_URL/e2e_vcast24_screenshots.tar.gz -T e2e_vcast24_screenshots.tar.gz
+            URL="$BASE_ARTIFACTORY_URL/e2e_vcast24_screenshots/"
+            curl -H "X-Explode-Archive: true" -H "X-JFrog-Art-Api:${{ secrets.ARTIFACTORY_TOKEN }}" -X PUT $URL -T e2e_vcast24_screenshots.tar.gz
             cd ../../..
-            echo "[Screenshots]($ARTIFACTORY_URL/e2e_vcast24_screenshots.tar.gz)" >> $GITHUB_STEP_SUMMARY
+            echo "[Screenshots]($URL)" >> $GITHUB_STEP_SUMMARY
           fi
 
       - name: Save dependencies - node

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -131,7 +131,7 @@ jobs:
 
     container:
       image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vcast_base
-      options: --user vcast_user -v /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket:rw
+      options: --user vcast_user
 
     steps:
       - name: Start forward proxy
@@ -252,7 +252,7 @@ jobs:
 
     container:
       image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vcast_base
-      options: --user vcast_user -v /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket:rw
+      options: --user vcast_user
 
     steps:
       - name: Start forward proxy
@@ -373,7 +373,7 @@ jobs:
 
     container:
       image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vcast_base
-      options: --user vcast_user -v /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket:rw
+      options: --user vcast_user
 
     steps:
       - name: Start forward proxy

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -11,6 +11,7 @@ on:
   workflow_dispatch:
 jobs:
   unit-tests:
+    if: github.event.pull_request.draft == false
     permissions: write-all
     runs-on: [self-hosted, vscode-vcast]
 
@@ -124,6 +125,7 @@ jobs:
           --data-binary "@${{ env.VSIX_FILE }}"
 
   e2e-tests-23:
+    if: github.event.pull_request.draft == false
     permissions: write-all
     runs-on: [ self-hosted, vscode-vcast]
 
@@ -244,6 +246,7 @@ jobs:
           key: ${{ runner.os }}-dependencies-webdriver-vscode
 
   e2e-tests-24:
+    if: github.event.pull_request.draft == false
     permissions: write-all
     runs-on: [ self-hosted, vscode-vcast]
 

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -367,7 +367,7 @@ jobs:
           key: ${{ runner.os }}-dependencies-webdriver-vscode
 
   code-formatting:
-    if: contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
+    if: github.event.pull_request.draft == false
     permissions: write-all
     runs-on: [ self-hosted, vscode-vcast]
 

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -362,3 +362,33 @@ jobs:
           path: |
             tests/internal/e2e/.wdio-vscode-service
           key: ${{ runner.os }}-dependencies-webdriver-vscode
+
+  code-formatting:
+    if: contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name)
+    permissions: write-all
+    runs-on: [ self-hosted, vscode-vcast]
+
+    container:
+      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vcast_base
+      options: --user vcast_user -v /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket:rw
+
+    steps:
+      - name: Start forward proxy
+        run: |
+          sudo /usr/sbin/squid
+          NEW_PROXY="http://$(hostname --ip-address):3128"
+          echo "HTTP_PROXY=$NEW_PROXY" >> $GITHUB_ENV
+          echo "HTTPS_PROXY=$NEW_PROXY" >> $GITHUB_ENV
+          echo "http_proxy=$NEW_PROXY" >> $GITHUB_ENV
+          echo "https_proxy=$NEW_PROXY" >> $GITHUB_ENV
+          echo "GLOBAL_AGENT_HTTP_PROXY=$NEW_PROXY" >> $GITHUB_ENV
+          echo "GLOBAL_AGENT_HTTPS_PROXY=$NEW_PROXY" >> $GITHUB_ENV
+
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Black
+        shell: bash
+        run: |
+          /home/vcast_user/.venv/bin/python -m black . --check
+          exit $?

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -221,7 +221,7 @@ jobs:
           if [ $count != 0 ] ; then
             cd tests/internal/e2e
             tar -cvzf e2e_vcast23_screenshots.tar.gz *.png > /dev/null
-            URL="$BASE_ARTIFACTORY_URL/e2e_vcast23_screenshots/"
+            URL="$ARTIFACTORY_URL/e2e_vcast23_screenshots/"
             curl -H "X-Explode-Archive: true" -H "X-JFrog-Art-Api:${{ secrets.ARTIFACTORY_TOKEN }}" -X PUT $URL -T e2e_vcast23_screenshots.tar.gz
             cd ../../..
             echo "[Screenshots]($URL)" >> $GITHUB_STEP_SUMMARY
@@ -341,7 +341,7 @@ jobs:
           if [ $count != 0 ] ; then
             cd tests/internal/e2e
             tar -cvzf e2e_vcast24_screenshots.tar.gz *.png > /dev/null
-            URL="$BASE_ARTIFACTORY_URL/e2e_vcast24_screenshots/"
+            URL="$ARTIFACTORY_URL/e2e_vcast24_screenshots/"
             curl -H "X-Explode-Archive: true" -H "X-JFrog-Art-Api:${{ secrets.ARTIFACTORY_TOKEN }}" -X PUT $URL -T e2e_vcast24_screenshots.tar.gz
             cd ../../..
             echo "[Screenshots]($URL)" >> $GITHUB_STEP_SUMMARY

--- a/tests/internal/e2e/get_e2e_summary_for_gh_actions.py
+++ b/tests/internal/e2e/get_e2e_summary_for_gh_actions.py
@@ -6,50 +6,62 @@ from pathlib import Path
 
 
 if not len(sys.argv) == 2:
-    raise Exception('python get_e2e_summary_for_gh_actions.py <path-to-log-file>')
+    raise Exception("python get_e2e_summary_for_gh_actions.py <path-to-log-file>")
 
 log_file = Path(sys.argv[1])
 if not log_file.is_file():
-    raise Exception(f'{log_file} does not exist or is not a file')
+    raise Exception(f"{log_file} does not exist or is not a file")
 
-REPOSITORY_PATH = str(Path(os.path.realpath(__file__)).parent.parent.parent.parent.absolute())
+REPOSITORY_PATH = str(
+    Path(os.path.realpath(__file__)).parent.parent.parent.parent.absolute()
+)
 
 
 def get_link_from_error(text: str) -> str:
-    errors = re.findall(re.compile(r'^Error: .+?\(.*\)$', flags=re.DOTALL | re.MULTILINE), text)
-    ret = ''
+    errors = re.findall(
+        re.compile(r"^Error: .+?\(.*\)$", flags=re.DOTALL | re.MULTILINE), text
+    )
+    ret = ""
     for error in errors:
-        files = re.findall(re.compile(r'(?:Context\.<anonymous>\s*|Error: Timeout of.*)\(([^)]+)\)'), error)
+        files = re.findall(
+            re.compile(r"(?:Context\.<anonymous>\s*|Error: Timeout of.*)\(([^)]+)\)"),
+            error,
+        )
         for file in files:
-            if ':' in file:
-                file_path, line_column = file.split(':', 1)
-                line = line_column.split(':')[0]
+            if ":" in file:
+                file_path, line_column = file.split(":", 1)
+                line = line_column.split(":")[0]
             else:
                 file_path = file
                 line = 0
-            file_path = file_path.replace(REPOSITORY_PATH + '/', '')
+            file_path = file_path.replace(REPOSITORY_PATH + "/", "")
             ret += f'[{file_path}](https://github.com/{os.getenv("GITHUB_REPOSITORY")}/blob/{os.getenv("GITHUB_SHA")}/{file_path}#L{line})\n'
     if ret:
-        ret = f'#### Links to source files\n{ret}'
+        ret = f"#### Links to source files\n{ret}"
     return ret
 
 
-logs = log_file.read_text(encoding='utf-8')
-specs = re.findall(re.compile(r'\s"spec" Reporter:.+?Spec Files:.+?$', flags=re.DOTALL | re.MULTILINE), logs)
+logs = log_file.read_text(encoding="utf-8")
+specs = re.findall(
+    re.compile(r'\s"spec" Reporter:.+?Spec Files:.+?$', flags=re.DOTALL | re.MULTILINE),
+    logs,
+)
 if not specs:
-    res = 'Specs not found in logs'
+    res = "Specs not found in logs"
 else:
-    res = ''
+    res = ""
     for spec in specs:
-        clean_spec = re.compile(r'\x1b[^m]*m').sub('', spec.strip())
-        clean_spec = re.sub(re.compile(r'^\[.+?\]\s', flags=re.DOTALL | re.MULTILINE), '', clean_spec)
-        workers_executions = re.split(re.compile(r'-+\n|\nSpec Files:'), clean_spec)[1:]
-        final_line = f'Spec Files:{workers_executions.pop(-1)}'
-        res += '## Spec\n'
+        clean_spec = re.compile(r"\x1b[^m]*m").sub("", spec.strip())
+        clean_spec = re.sub(
+            re.compile(r"^\[.+?\]\s", flags=re.DOTALL | re.MULTILINE), "", clean_spec
+        )
+        workers_executions = re.split(re.compile(r"-+\n|\nSpec Files:"), clean_spec)[1:]
+        final_line = f"Spec Files:{workers_executions.pop(-1)}"
+        res += "## Spec\n"
         for execution in workers_executions:
-            res += f'```\n{execution.strip()}\n```\n'
+            res += f"```\n{execution.strip()}\n```\n"
             res += get_link_from_error(execution)
-        res += f'\n```\n{final_line.strip()}\n```'
+        res += f"\n```\n{final_line.strip()}\n```"
 
-with open(f'{Path(log_file.parent, "gh_e2e_summary.md")}', 'w', encoding='utf-8') as f:
+with open(f'{Path(log_file.parent, "gh_e2e_summary.md")}', "w", encoding="utf-8") as f:
     f.write(res)


### PR DESCRIPTION
- The E2E tests were already ending when a failure happened, but GHA was not detecting the failure. We now parse the output to see if the suite has failed, and in case, we return a 1 status code.
- The runs naming has been changed to "branch-name is being tested"
- We have a new job that checks the python scripts format with black
- We don't run the jobs if the trigger comes from a draft PR
- We upload screenshots separately (not in an archive)
- Removed container's option ` -v /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket:rw`, suspected to be the reason why the containers hang when running E2E tests at the same time