### PR TITLE
Switching to non-composite EnricoMi/publish-unit-test-result-action

### DIFF
--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -62,7 +62,7 @@ jobs:
         run: npm run gh-test | tee output.txt
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        uses: EnricoMi/publish-unit-test-result-action/linux@v2
         if: always()
         with:
           check_name: "Unit Test results"
@@ -195,7 +195,7 @@ jobs:
           export BRANCH_REF=${{ github.ref }} && ./tests/internal/e2e/run_e2e_tests.sh
 
       - name: Publish e2e tests results
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        uses: EnricoMi/publish-unit-test-result-action/linux@v2
         if: always()
         with:
           check_name: "E2e Test results - Vcast 23"
@@ -316,7 +316,7 @@ jobs:
           export USE_VCAST_24=True && export BRANCH_REF=${{ github.ref }} && ./tests/internal/e2e/run_e2e_tests.sh
 
       - name: Publish e2e tests results
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        uses: EnricoMi/publish-unit-test-result-action/linux@v2
         if: always()
         with:
           check_name: "E2e Test results - Vcast 24"


### PR DESCRIPTION
The composite version of EnricoMi/publish-unit-test-result-action is deprecated, we can use the standard version for linux now.