### PR TITLE
Simpifying deletion E2E tests and re-adding tests for generating and deleting tests at environment level

### DIFF
--- a/tests/internal/e2e/test/specs/vcast_testgen_bugs_2.test.ts
+++ b/tests/internal/e2e/test/specs/vcast_testgen_bugs_2.test.ts
@@ -104,9 +104,10 @@ describe("vTypeCheck VS Code Extension", () => {
       testGenMethod.BasisPath
     );
     await validateTestDeletionForFunction(
-      QUOTES_ENV,
       QUOTES_EXAMPLE_UNIT,
-      QUOTES_EXAMPLE_FUNCTION
+      QUOTES_EXAMPLE_FUNCTION,
+      "BASIS-PATH-001",
+      1
     );
   });
 
@@ -142,9 +143,10 @@ describe("vTypeCheck VS Code Extension", () => {
         testGenMethod.ATG
       );
       await validateTestDeletionForFunction(
-        QUOTES_ENV,
         QUOTES_EXAMPLE_UNIT,
-        QUOTES_EXAMPLE_FUNCTION
+        QUOTES_EXAMPLE_FUNCTION,
+        "ATG-TEST-1",
+        1
       );
     } else {
       console.log("Skipping ATG tests");

--- a/tests/internal/e2e/test/specs/vcast_testgen_env.test.ts
+++ b/tests/internal/e2e/test/specs/vcast_testgen_env.test.ts
@@ -8,7 +8,7 @@ import {
   updateTestID,
   testGenMethod,
   deleteAllTestsForEnv,
-  validateTestDeletionForEnv,
+  validateTestDeletionForFunction,
   generateAndValidateAllTestsFor,
   cleanup,
 } from "../test_utils/vcast_utils";
@@ -166,7 +166,21 @@ describe("vTypeCheck VS Code Extension", () => {
     console.log(
       `Validating deletion of all BASIS PATH tests for the environment ${envName}`
     );
-    await validateTestDeletionForEnv(envName);
+    // spot checking a single function and test will do
+    // we just want to make sure that the tree update got triggered
+    await validateTestDeletionForFunction(
+      "database",
+      "DataBase::GetTableRecord",
+      "BASIS-PATH-001",
+      1
+    );
+
+    await validateTestDeletionForFunction(
+      "manager",
+      "Manager::ClearTable",
+      "BASIS-PATH-001",
+      1
+    );
   });
 
   it("should correctly generate all ATG tests for the environment", async () => {
@@ -190,7 +204,21 @@ describe("vTypeCheck VS Code Extension", () => {
       console.log(
         `Validating deletion of all ATG tests for the environment ${envName}`
       );
-      await validateTestDeletionForEnv(envName);
+      // spot checking a single function and test will do
+      // we just want to make sure that the tree update got triggered
+      await validateTestDeletionForFunction(
+        "database",
+        "DataBase::GetTableRecord",
+        "ATG-TEST-1",
+        1
+      );
+
+      await validateTestDeletionForFunction(
+        "manager",
+        "Manager::ClearTable",
+        "ATG-TEST-1",
+        1
+      );
     }
   });
 

--- a/tests/internal/e2e/test/specs/vcast_testgen_func.test.ts
+++ b/tests/internal/e2e/test/specs/vcast_testgen_func.test.ts
@@ -186,9 +186,10 @@ describe("vTypeCheck VS Code Extension", () => {
       "Validating deletion of all BASIS PATH tests for function DataBase::GetTableRecord"
     );
     await validateTestDeletionForFunction(
-      envName,
       "database",
-      "DataBase::GetTableRecord"
+      "DataBase::GetTableRecord",
+      "BASIS-PATH-001",
+      1
     );
   });
 
@@ -232,9 +233,10 @@ describe("vTypeCheck VS Code Extension", () => {
         "Validate deletion of all ATG tests for function DataBase::GetTableRecord"
       );
       await validateTestDeletionForFunction(
-        envName,
         "database",
-        "DataBase::GetTableRecord"
+        "DataBase::GetTableRecord",
+        "ATG-TEST-1",
+        1
       );
     } else {
       console.log("Skipping ATG tests");

--- a/tests/internal/e2e/test/specs/vcast_testgen_unit.test.ts
+++ b/tests/internal/e2e/test/specs/vcast_testgen_unit.test.ts
@@ -10,7 +10,7 @@ import {
   generateAllTestsForUnit,
   validateGeneratedTestsForUnit,
   deleteAllTestsForUnit,
-  validateTestDeletionForUnit,
+  validateTestDeletionForFunction,
   cleanup,
 } from "../test_utils/vcast_utils";
 
@@ -166,9 +166,16 @@ describe("vTypeCheck VS Code Extension", () => {
     console.log("Deleting all BASIS PATH tests for unit database");
     await deleteAllTestsForUnit("database", testGenMethod.BasisPath);
     console.log(
-      "Validating deletion of all BASIS PATH tests for unit database"
+      "Validating deletion of BASIS PATH tests for unit database"
     );
-    await validateTestDeletionForUnit(envName, "database");
+    // spot checking a single function and test will do
+    // we just want to make sure that the tree update got triggered
+    await validateTestDeletionForFunction(
+      "database",
+      "DataBase::GetTableRecord",
+      "BASIS-PATH-001",
+      1
+    );
   });
 
   it("should correctly generate all ATG tests for unit", async () => {
@@ -196,7 +203,14 @@ describe("vTypeCheck VS Code Extension", () => {
       console.log("Deleting all ATG tests for unit database");
       await deleteAllTestsForUnit("database", testGenMethod.ATG);
       console.log("Validating deletion of all ATG tests for unit database");
-      await validateTestDeletionForUnit(envName, "database");
+      // spot checking a single function and test will do
+      // we just want to make sure that the tree update got triggered
+      await validateTestDeletionForFunction(
+        "database",
+        "DataBase::GetTableRecord",
+        "ATG-TEST-1",
+        1
+      );
     } else {
       console.log("Skipping ATG tests");
     }

--- a/tests/internal/e2e/test/test_utils/vcast_utils.ts
+++ b/tests/internal/e2e/test/test_utils/vcast_utils.ts
@@ -522,44 +522,15 @@ export async function validateTestDeletionForUnit(
 }
 
 export async function validateTestDeletionForFunction(
-  envName: string,
   unitName: string,
-  functionName: string
+  functionName: string,
+  spotCheckTestName: string,
+  totalNumOfTestsForMethod: number
 ) {
-  const vcastTestingViewContent = await getViewContent("Testing");
-  let doneValidating = true;
-  for (const vcastTestingViewContentSection of await vcastTestingViewContent.getSections()) {
-    for (const visibleItem of await vcastTestingViewContentSection.getVisibleItems()) {
-      await visibleItem.select();
-
-      const subprogramGroup = visibleItem as CustomTreeItem;
-
-      if ((await subprogramGroup.getTooltip()).includes(envName)) {
-        for (const unit of await subprogramGroup.getChildren()) {
-          const unitNameTooltip = await unit.getTooltip();
-
-          if (unitNameTooltip.includes(unitName)) {
-            for (const method of await unit.getChildren()) {
-              const methodNameTooltip = await method.getTooltip();
-
-              // this is flaky, it sometimes takes manager as Child element
-              if (methodNameTooltip.includes(functionName)) {
-                await browser.waitUntil(
-                  async () => (await method.hasChildren()) === false,
-                  { timeout: 8000 }
-                );
-                return;
-              }
-            }
-            break;
-          }
-        }
-        // getVisibleItems() literally gets the visible items, including leaves in the structure
-        // important to stop the loop here, otherwise wdio starts doing random things and hangs
-        break;
-      }
-    }
-  }
+    // Only checking if one of the tests can be found
+    // This indicates that the test tree got refreshed
+    await validateSingleTestDeletion(unitName, functionName, spotCheckTestName, totalNumOfTestsForMethod)
+  
 }
 
 export async function generateAndValidateAllTestsFor(
@@ -860,7 +831,7 @@ export async function validateSingleTestDeletion(
             testName,
             totalTestsForFunction
           )) as CustomTreeItem) === undefined,
-        { timeout: 20000 }
+        { timeout: 5000 }
       );
 
       break;

--- a/tests/internal/e2e/test/wdio.conf.ts
+++ b/tests/internal/e2e/test/wdio.conf.ts
@@ -90,10 +90,9 @@ fullTestSpecs = fullTestSpecs.concat([
   "./**/**/vcast_testgen_bugs_2.test.ts",
   "./**/**/vcast_testgen_func.test.ts",
   "./**/**/vcast_testgen_unit.test.ts",
+  "./**/**/vcast_testgen_env.test.ts"
 ]);
-// this test takes very long and it's not that critical
-// if (process.env["BRANCH_REF"] == "refs/heads/main")
-//   fullTestSpecs = fullTestSpecs.concat(["./**/**/vcast_testgen_env.test.ts"])
+
 export const config: Options.Testrunner = {
   //
   // ====================


### PR DESCRIPTION
- We only check single tests per env/function/unit now when verifying deletion
  - This indicates already that the test tree got updated, no need to check every test
- Re-added the checks at environment level now that the respective tests don't take so long
  - Closes Issue #113 