### PR TITLE
Add tests for return type + parameterization

### DIFF
--- a/python/tstUtilities.py
+++ b/python/tstUtilities.py
@@ -666,7 +666,7 @@ def getParameterTypesFromParameterization(functionObject):
     # first build the list of parameter types
     paramTypes = list()
     parameterizedName = functionObject.parameterization
-    parameterString = parameterizedName.split("(")[1].split(")")[0]
+    parameterString = parameterizedName.split("(", 1)[1].rsplit(")", 1)[0]
 
     paramTypes = list()
     commasOfInterest = findCommas(parameterString)

--- a/tests/python/test_python.py
+++ b/tests/python/test_python.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env vpython
+
+#
+# NOTE: we cannot use PyTest here as vpython does not ship with it
+#
+
+import sys
+import os
+from collections import namedtuple
+
+sys.path.insert(0, os.path.join("..", "..", "python"))
+
+import tstUtilities
+
+MockFunctionObject = namedtuple("MockFunctionObject", "parameterization")
+
+
+def check_values(func, parameterization, expected):
+    mockFunctionObject = MockFunctionObject(parameterization)
+    actual = func(mockFunctionObject)
+    assert actual == expected, f"{actual} != {expected}"
+
+
+def test_getReturnType():
+    to_check = [
+        # Function that takes three ints, returns an int
+        ("(int,int,int)int", "int"),
+        # Function that takes a void(*)(int,int) fp and returns a
+        # void(*)(int,int) fp
+        ("(void (*)(int, int))void (*)(int, int)", "void (*)(int, int)"),
+        # Function that takes a template + and int and returns a template
+        # containing a void(*)(void) fp
+        ("(array<int, 1>,int)array<void (*)(void), 1>", "array<void (*)(void), 1>"),
+    ]
+
+    for parameterization, expected in to_check:
+        check_values(tstUtilities.getReturnType, parameterization, expected)
+
+
+def test_getParameterTypesFromParameterization():
+    to_check = [
+        # Function that takes three ints
+        ("(int,int,int)", ["int", "int", "int"]),
+        # Function that takes two ints, and two void(*)(int, int) fps
+        (
+            "(int,int,void (*)(int, int),void (*)(int, int))",
+            ["int", "int", "void (*)(int, int)", "void (*)(int, int)"],
+        ),
+        # Function that takes an template and int
+        ("(std::array<int, 1UL>,int)", ["std::array<int, 1UL>", "int"]),
+    ]
+
+    for parameterization, expected in to_check:
+        check_values(
+            tstUtilities.getParameterTypesFromParameterization,
+            parameterization,
+            expected,
+        )
+
+
+def main():
+    test_getReturnType()
+    test_getParameterTypesFromParameterization()
+
+
+if __name__ == "__main__":
+    main()
+
+# EOF

--- a/tests/python/test_python.py
+++ b/tests/python/test_python.py
@@ -6,9 +6,12 @@
 
 import sys
 import os
+import pathlib
 from collections import namedtuple
 
-sys.path.insert(0, os.path.join("..", "..", "python"))
+# Get the path to where our packages are
+path_to_packages = pathlib.Path(__file__).parent.parent.parent / "python"
+sys.path.insert(0, str(path_to_packages))
 
 import tstUtilities
 


### PR DESCRIPTION
Adds tests + fixes some bugs on return types + parameterization 

```c
void foo(int, int, void (*)(int, int), void (*)(int, int))
{
}
```