### PR TITLE
Fix some bugs in coded test generation

### DIFF
--- a/python/tstUtilities.py
+++ b/python/tstUtilities.py
@@ -716,7 +716,7 @@ def getReturnType(functionObject):
     constFlag = "const"
     if returnType.endswith(constFlag):
         # strip "const$"
-        returnType = returnType[: -(len(constFlag))]
+        returnType = returnType[: -(len(constFlag))].strip()
 
     if returnType == None or len(returnType) == 0:
         returnType = "void"

--- a/python/tstUtilities.py
+++ b/python/tstUtilities.py
@@ -574,7 +574,7 @@ def getUnitAndFunctionObjects(api, unitString, functionString):
     return returnUnitList, returnFunctionList
 
 
-def createFunctionSignature(functionObject, parameterTypeList):
+def createFunctionSignature(api, functionObject, parameterTypeList):
     """
     Create the signature for a vmock object, something like this:
         ::vunit::CallCtx<myClass> vunit_ctx, const char* param1
@@ -584,6 +584,10 @@ def createFunctionSignature(functionObject, parameterTypeList):
     instantiatingClass = ""
     if "::" in functionObject.name:
         instantiatingClass = functionObject.name.rsplit("::", 1)[0]
+        # We need to check if we get a class name after splitting; we only use
+        # if it is a class
+        if api.Type.get_by_typemark(instantiatingClass) is None:
+            instantiatingClass = ""
 
     # the static part of the signature looks like this,
     # we will append the parameters next
@@ -783,7 +787,7 @@ def getUsageStrings(functionObject, parameterTypeList, vmockFunctionName):
     return enableComment, disableComment
 
 
-def generateVMockDefitionForUnitAndFunction(unitObject, functionObject):
+def generateVMockDefitionForUnitAndFunction(api, unitObject, functionObject):
     vmockFunctionName = getFunctionName(functionObject)
 
     # TBD today - need new type string from vcast
@@ -793,7 +797,7 @@ def generateVMockDefitionForUnitAndFunction(unitObject, functionObject):
     # the parameterized name, vs using the parameter typemark
     parameterTypeList = getParameterTypesFromParameterization(functionObject)
 
-    signatureString = createFunctionSignature(functionObject, parameterTypeList)
+    signatureString = createFunctionSignature(api, functionObject, parameterTypeList)
     returnType = getReturnType(functionObject)
 
     enableComment, disableComment = getUsageStrings(
@@ -868,7 +872,7 @@ def processVMockDefinition(enviroName, lineSoFar):
         functionObject = functionObjectList[0]
 
         whatToReturn = generateVMockDefitionForUnitAndFunction(
-            unitObject, functionObject
+            api, unitObject, functionObject
         )
 
         returnData.choiceKind = choiceKindType.Snippet

--- a/python/vmockGenerator.py
+++ b/python/vmockGenerator.py
@@ -68,7 +68,7 @@ def generateAllVMockDefinitions(enviroPath):
                 # When we've found the usage line
                 if line.startswith(enableStubPrefix):
                     # Grab the invocation
-                    invocation = line[len(enableStubPrefix) :]
+                    invocation = line[len(enableStubPrefix) + 2 :]
 
                     # It should now be the vmock_session content
                     assert invocation.startswith("vmock_session.")

--- a/python/vmockGenerator.py
+++ b/python/vmockGenerator.py
@@ -54,7 +54,7 @@ def generateAllVMockDefinitions(enviroPath):
             # Note: we're doing this with string processing here to avoid
             # changing too much of the actual code
             mock_content = generateVMockDefitionForUnitAndFunction(
-                unitObject, functionObject
+                api, unitObject, functionObject
             )
 
             # The vmock usage line

--- a/tests/python/test_python.py
+++ b/tests/python/test_python.py
@@ -40,11 +40,13 @@ def test_getReturnType():
         # Function that takes a template + and int and returns a template
         # containing a void(*)(void) fp
         ("(array<int, 1>,int)array<void (*)(void), 1>", "array<void (*)(void), 1>"),
-        # Const function return const vector
+        # Const function returning const vector
         (
             "()const std::vector<int, std::allocator<int>>const",
             "const std::vector<int, std::allocator<int>>",
         ),
+        # Const function returning const int
+        ("()const int const", "const int"),
     ]
 
     # These tests don't need a mangled name

--- a/tests/python/test_python.py
+++ b/tests/python/test_python.py
@@ -89,22 +89,37 @@ def test_getParameterTypesFromParameterization():
 def test_getFunctionName():
     to_check = [
         # We want to use the mangled name for operators to make sure the functions are unique
-        ("Moo<int>::operator==", "_ZN3MooIiEeqEi", "vmock_test__ZN3MooIiEeqEi"),
+        (
+            "Moo<int>::operator==",
+            "_ZN3MooIiEeqEi",
+            "vmock_test_Moo_operator_symbol",
+            "vmock_test__ZN3MooIiEeqEi",
+        ),
         # Make sure we drop template params (we don't care about the mangled name in this case)
-        ("Moo<int>::foo", "", "vmock_test_Moo_foo"),
+        ("Moo<int>::foo", "", "vmock_test_Moo_foo", "vmock_test_Moo_foo"),
     ]
 
     # These tests don't need parameterization
     parameterization = None
 
-    for name, mangled_name, expected in to_check:
+    for name, mangled_name, expected_not_mangled, expected_mangled in to_check:
         check_values(
             tstUtilities.getFunctionName,
             parameterization,
             mangled_name,
             name,
-            expected,
+            expected_not_mangled,
         )
+
+        os.environ[tstUtilities.ENV_VCAST_TEST_EXPLORER_MANGLED_FOR_OPERATOR] = "1"
+        check_values(
+            tstUtilities.getFunctionName,
+            parameterization,
+            mangled_name,
+            name,
+            expected_mangled,
+        )
+        del os.environ[tstUtilities.ENV_VCAST_TEST_EXPLORER_MANGLED_FOR_OPERATOR]
 
 
 def main():


### PR DESCRIPTION
This fixes four bugs:

* if a `const` function returned a template, we removed the trailing `>`, giving a syntax error
* if a function was templated then we generated a mock including the template argument, giving a syntax error
* if a function had `operator` in it, we used to remove the operator type -- this caused an error when we had multiple operators, so now we use the mangled name (not pretty, but gives unique names).
* if a function was in a namepsace, we would previously use the namespace name as a class type, giving a syntax error

Tests added for the first three (testing the namespace one requires a full API instance).