### PR TITLE
Gha e2e jobs parallelisation

### DIFF
--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -368,5 +368,5 @@ jobs:
       - name: Black
         shell: bash
         run: |
-          /home/vcast_user/.venv/bin/python -m black . --check
+          /home/vcast_user/.venv/bin/python -m black . --check --extend-exclude '/(.*venv.*)/'
           exit $?

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -110,14 +110,14 @@ jobs:
           echo "VSIX_FILE=$VSIX_FILE" >> $GITHUB_ENV
 
       - name: Upload vectorcasttestexplorer artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: vectorcasttestexplorer
           path: ${{ env.VSIX_FILE }}
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: coverage
@@ -284,7 +284,7 @@ jobs:
             ./tests/internal/e2e/test_results/*.xml
 
       - name: Uploading screenshots
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         if: always()
         env:
           ARTIFACT_NAME: e2e_screenshots_${{ matrix.version }}_${{ matrix.group }}

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -36,13 +36,16 @@ jobs:
         uses: actions/checkout@v4
         continue-on-error: true
 
-      - name: Retry Checkout if first attempt failed
-        if: steps.checkout.outcome == 'failure'
+      - name: Wait before retry
+        id: should-retry-checkout
+        if: failure()
+        continue-on-error: true
         run: |
           sleep 10
+          exit 1
 
       - name: Check out repository (retry)
-        if: steps.checkout.outcome == 'failure'
+        if: failure()
         uses: actions/checkout@v4
 
       # Run tests
@@ -153,13 +156,16 @@ jobs:
         uses: actions/checkout@v4
         continue-on-error: true
 
-      - name: Retry Checkout if first attempt failed
-        if: steps.checkout.outcome == 'failure'
+      - name: Wait before retry
+        id: should-retry-checkout
+        if: failure()
+        continue-on-error: true
         run: |
           sleep 10
+          exit 1
 
       - name: Check out repository (retry)
-        if: steps.checkout.outcome == 'failure'
+        if: failure()
         uses: actions/checkout@v4
 
       - name: Install dependencies
@@ -211,13 +217,16 @@ jobs:
         uses: actions/checkout@v4
         continue-on-error: true
 
-      - name: Retry Checkout if first attempt failed
-        if: steps.checkout.outcome == 'failure'
+      - name: Wait before retry
+        id: should-retry-checkout
+        if: failure()
+        continue-on-error: true
         run: |
           sleep 10
+          exit 1
 
       - name: Check out repository (retry)
-        if: steps.checkout.outcome == 'failure'
+        if: failure()
         uses: actions/checkout@v4
 
       - name: Restore cached dependencies
@@ -344,13 +353,16 @@ jobs:
         uses: actions/checkout@v4
         continue-on-error: true
 
-      - name: Retry Checkout if first attempt failed
-        if: steps.checkout.outcome == 'failure'
+      - name: Wait before retry
+        id: should-retry-checkout
+        if: failure()
+        continue-on-error: true
         run: |
           sleep 10
+          exit 1
 
       - name: Check out repository (retry)
-        if: steps.checkout.outcome == 'failure'
+        if: failure()
         uses: actions/checkout@v4
 
       - name: Black

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -32,7 +32,18 @@ jobs:
           echo "GLOBAL_AGENT_HTTPS_PROXY=$NEW_PROXY" >> $GITHUB_ENV
 
       - name: Check out repository
-        uses: actions/checkout@v3
+        id: checkout
+        uses: actions/checkout@v4
+        continue-on-error: true
+
+      - name: Retry Checkout if first attempt failed
+        if: steps.checkout.outcome == 'failure'
+        run: |
+          sleep 10
+
+      - name: Check out repository (retry)
+        if: steps.checkout.outcome == 'failure'
+        uses: actions/checkout@v4
 
       # Run tests
       - name: Restore cached dependencies
@@ -96,14 +107,14 @@ jobs:
           echo "VSIX_FILE=$VSIX_FILE" >> $GITHUB_ENV
 
       - name: Upload vectorcasttestexplorer artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: vectorcasttestexplorer
           path: ${{ env.VSIX_FILE }}
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: coverage
@@ -137,8 +148,19 @@ jobs:
       version_group_matrix: ${{ steps.set-matrix.outputs.matrix }}
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - name: Check out repository
+        id: checkout
+        uses: actions/checkout@v4
+        continue-on-error: true
+
+      - name: Retry Checkout if first attempt failed
+        if: steps.checkout.outcome == 'failure'
+        run: |
+          sleep 10
+
+      - name: Check out repository (retry)
+        if: steps.checkout.outcome == 'failure'
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: npm install tsx
@@ -185,7 +207,18 @@ jobs:
           echo "GLOBAL_AGENT_HTTPS_PROXY=$NEW_PROXY" >> $GITHUB_ENV
 
       - name: Check out repository
-        uses: actions/checkout@v3
+        id: checkout
+        uses: actions/checkout@v4
+        continue-on-error: true
+
+      - name: Retry Checkout if first attempt failed
+        if: steps.checkout.outcome == 'failure'
+        run: |
+          sleep 10
+
+      - name: Check out repository (retry)
+        if: steps.checkout.outcome == 'failure'
+        uses: actions/checkout@v4
 
       - name: Restore cached dependencies
         id: cache-dependencies-restore
@@ -242,7 +275,7 @@ jobs:
             ./tests/internal/e2e/test_results/*.xml
 
       - name: Uploading screenshots
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         env:
           ARTIFACT_NAME: e2e_screenshots_${{ matrix.version }}_${{ matrix.group }}
@@ -307,7 +340,18 @@ jobs:
           echo "GLOBAL_AGENT_HTTPS_PROXY=$NEW_PROXY" >> $GITHUB_ENV
 
       - name: Check out repository
-        uses: actions/checkout@v3
+        id: checkout
+        uses: actions/checkout@v4
+        continue-on-error: true
+
+      - name: Retry Checkout if first attempt failed
+        if: steps.checkout.outcome == 'failure'
+        run: |
+          sleep 10
+
+      - name: Check out repository (retry)
+        if: steps.checkout.outcome == 'failure'
+        uses: actions/checkout@v4
 
       - name: Black
         shell: bash

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -124,14 +124,53 @@ jobs:
           $upload_url \
           --data-binary "@${{ env.VSIX_FILE }}"
 
-  e2e-tests-23:
+  generate-matrix:
     if: github.event.pull_request.draft == false
     permissions: write-all
-    runs-on: [ self-hosted, vscode-vcast]
+    runs-on: [self-hosted, vscode-vcast]
 
     container:
       image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vcast_base
       options: --user vcast_user
+
+    outputs:
+      version_group_matrix: ${{ steps.set-matrix.outputs.matrix }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: npm install tsx
+
+      - name: Set jobs matrix
+        id: set-matrix
+        run: |
+          cd tests/internal/e2e/test
+          npx tsx get_gha_matrix.ts
+          echo "matrix=$(cat gha_matrix.json)" >> "$GITHUB_OUTPUT"
+
+  e2e-tests:
+    needs: generate-matrix
+    if: github.event.pull_request.draft == false
+    permissions: write-all
+    runs-on: [self-hosted, vscode-vcast]
+
+    container:
+      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vcast_base
+      options: --user vcast_user
+
+    strategy:
+      matrix:
+        include: ${{ fromJSON(needs.generate-matrix.outputs.version_group_matrix) }}
+
+    env:
+      BRANCH_REF: ${{ github.ref }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
+      GITHUB_SHA: ${{ github.sha }}
+      USE_VCAST_24: ${{ matrix.version == 24 && 'True' || 'False' }}
+      RUN_BY_GROUP: "True"
+      RUN_GROUP_NAME: ${{ matrix.group }}
 
     steps:
       - name: Start forward proxy
@@ -188,17 +227,16 @@ jobs:
           key: ${{ runner.os }}-dependencies-webdriver-vscode
 
       - name: Run tests
-        env:
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_SHA: ${{ github.sha }}
         run: |
-          export BRANCH_REF=${{ github.ref }} && ./tests/internal/e2e/run_e2e_tests.sh
+          ./tests/internal/e2e/run_e2e_tests.sh
 
       - name: Publish e2e tests results
         uses: EnricoMi/publish-unit-test-result-action/linux@v2
         if: always()
+        env:
+          CHECK_NAME: E2e Test results - Vcast ${{ matrix.version }} - Group ${{ matrix.group }}
         with:
-          check_name: "E2e Test results - Vcast 23"
+          check_name: ${{ env.CHECK_NAME }}
           large_files: true
           files: |
             ./tests/internal/e2e/test_results/*.xml
@@ -206,14 +244,16 @@ jobs:
       - name: Uploading screenshots
         uses: actions/upload-artifact@v3
         if: always()
+        env:
+          ARTIFACT_NAME: e2e_screenshots_${{ matrix.version }}_${{ matrix.group }}
         with:
-          name: e2e_screenshots_23
+          name: ${{ env.ARTIFACT_NAME }}
           path: ./tests/internal/e2e/*.png
 
       - name: Show run summary
         if: always()
         run: |
-          echo "### Run summary - Vcast 23" >> $GITHUB_STEP_SUMMARY
+          echo "### Run summary - Vcast ${{ matrix.version }} - Group ${{ matrix.group }}" >> $GITHUB_STEP_SUMMARY
           content=$([ -s ./tests/internal/e2e/gh_e2e_summary.md ] && cat ./tests/internal/e2e/gh_e2e_summary.md || echo 'Not available')
           echo "${content}" >> $GITHUB_STEP_SUMMARY
           
@@ -222,130 +262,9 @@ jobs:
           count=`ls -1 tests/internal/e2e/*.png 2>/dev/null | wc -l`
           if [ $count != 0 ] ; then
             cd tests/internal/e2e
-            tar -cvzf e2e_vcast23_screenshots.tar.gz *.png > /dev/null
-            URL="$ARTIFACTORY_URL/e2e_vcast23_screenshots/"
-            curl -H "X-Explode-Archive: true" -H "X-JFrog-Art-Api:${{ secrets.ARTIFACTORY_TOKEN }}" -X PUT $URL -T e2e_vcast23_screenshots.tar.gz
-            cd ../../..
-            echo "[Screenshots]($URL)" >> $GITHUB_STEP_SUMMARY
-          fi
-
-      - name: Save dependencies - node
-        if: steps.cache-dependencies-restore-node.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            tests/internal/e2e/node_modules
-          key: ${{ runner.os }}-dependencies-${{ hashFiles('tests/internal/e2e/package.json') }}
-
-      - name: Save dependencies - vscode
-        if: always() && steps.cache-dependencies-restore-vscode.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            tests/internal/e2e/.wdio-vscode-service
-          key: ${{ runner.os }}-dependencies-webdriver-vscode
-
-  e2e-tests-24:
-    if: github.event.pull_request.draft == false
-    permissions: write-all
-    runs-on: [ self-hosted, vscode-vcast]
-
-    container:
-      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vcast_base
-      options: --user vcast_user
-
-    steps:
-      - name: Start forward proxy
-        run: |
-          sudo /usr/sbin/squid
-          NEW_PROXY="http://$(hostname --ip-address):3128"
-          echo "HTTP_PROXY=$NEW_PROXY" >> $GITHUB_ENV
-          echo "HTTPS_PROXY=$NEW_PROXY" >> $GITHUB_ENV
-          echo "http_proxy=$NEW_PROXY" >> $GITHUB_ENV
-          echo "https_proxy=$NEW_PROXY" >> $GITHUB_ENV
-          echo "GLOBAL_AGENT_HTTP_PROXY=$NEW_PROXY" >> $GITHUB_ENV
-          echo "GLOBAL_AGENT_HTTPS_PROXY=$NEW_PROXY" >> $GITHUB_ENV
-
-      - name: Check out repository
-        uses: actions/checkout@v3
-
-      - name: Restore cached dependencies
-        id: cache-dependencies-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            node_modules
-          key: ${{ runner.os }}-dependencies-${{ hashFiles('package.json') }}
-
-      - name: Install dependencies
-        if: steps.cache-dependencies-restore.outputs.cache-hit != 'true'
-        run: npm install
-
-      - name: Save dependencies
-        if: steps.cache-dependencies-restore.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
-        with:
-          path: |
-            node_modules
-          key: ${{ runner.os }}-dependencies-${{ hashFiles('package.json') }}
-
-      - name: Package with VSCE
-        run: vsce package
-
-      - name: Restore cached dependencies - node
-        id: cache-dependencies-restore-node
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            tests/internal/e2e/node_modules
-          key: ${{ runner.os }}-dependencies-${{ hashFiles('tests/internal/e2e/package.json') }}
-
-      - name: Restore cached dependencies - vscode
-        id: cache-dependencies-restore-vscode
-        uses: actions/cache/restore@v3
-        with:
-          path: |
-            tests/internal/e2e/.wdio-vscode-service
-          key: ${{ runner.os }}-dependencies-webdriver-vscode
-
-      - name: Run tests
-        env:
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_SHA: ${{ github.sha }}
-        run: |
-          export USE_VCAST_24=True && export BRANCH_REF=${{ github.ref }} && ./tests/internal/e2e/run_e2e_tests.sh
-
-      - name: Publish e2e tests results
-        uses: EnricoMi/publish-unit-test-result-action/linux@v2
-        if: always()
-        with:
-          check_name: "E2e Test results - Vcast 24"
-          large_files: true
-          files: |
-            ./tests/internal/e2e/test_results/*.xml
-
-      - name: Uploading screenshots
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: e2e_screenshots_24
-          path: ./tests/internal/e2e/*.png
-
-      - name: Show run summary
-        if: always()
-        run: |
-          echo "### Run summary - Vcast 24" >> $GITHUB_STEP_SUMMARY
-          content=$([ -s ./tests/internal/e2e/gh_e2e_summary.md ] && cat ./tests/internal/e2e/gh_e2e_summary.md || echo 'Not available')
-          echo "${content}" >> $GITHUB_STEP_SUMMARY
-          
-          COMMIT_DATE=$(git log -1 --format=%cd --date=format:%Y-%m-%dT%H:%M:%S)
-          ARTIFACTORY_URL="https://artifactory.vi.vector.int:443/artifactory/rds-build-packages-generic-dev/vscode/tests-results/${{ github.ref_name }}/$COMMIT_DATE-${{ github.sha }}"
-          count=`ls -1 tests/internal/e2e/*.png 2>/dev/null | wc -l`
-          if [ $count != 0 ] ; then
-            cd tests/internal/e2e
-            tar -cvzf e2e_vcast24_screenshots.tar.gz *.png > /dev/null
-            URL="$ARTIFACTORY_URL/e2e_vcast24_screenshots/"
-            curl -H "X-Explode-Archive: true" -H "X-JFrog-Art-Api:${{ secrets.ARTIFACTORY_TOKEN }}" -X PUT $URL -T e2e_vcast24_screenshots.tar.gz
+            tar -cvzf e2e_vcast${{ matrix.version }}_${{ matrix.group }}_screenshots.tar.gz *.png > /dev/null
+            URL="$ARTIFACTORY_URL/e2e_vcast${{ matrix.version }}_${{ matrix.group }}_screenshots/"
+            curl -H "X-Explode-Archive: true" -H "X-JFrog-Art-Api:${{ secrets.ARTIFACTORY_TOKEN }}" -X PUT $URL -T e2e_vcast${{ matrix.version }}_${{ matrix.group }}_screenshots.tar.gz
             cd ../../..
             echo "[Screenshots]($URL)" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Check out repository
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         continue-on-error: true
 
       - name: Wait before retry
@@ -46,7 +46,7 @@ jobs:
 
       - name: Check out repository (retry)
         if: failure()
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       # Run tests
       - name: Restore cached dependencies
@@ -153,7 +153,7 @@ jobs:
     steps:
       - name: Check out repository
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         continue-on-error: true
 
       - name: Wait before retry
@@ -166,7 +166,7 @@ jobs:
 
       - name: Check out repository (retry)
         if: failure()
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Install dependencies
         run: npm install tsx
@@ -214,7 +214,7 @@ jobs:
 
       - name: Check out repository
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         continue-on-error: true
 
       - name: Wait before retry
@@ -227,7 +227,7 @@ jobs:
 
       - name: Check out repository (retry)
         if: failure()
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Restore cached dependencies
         id: cache-dependencies-restore
@@ -350,7 +350,7 @@ jobs:
 
       - name: Check out repository
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         continue-on-error: true
 
       - name: Wait before retry
@@ -363,7 +363,7 @@ jobs:
 
       - name: Check out repository (retry)
         if: failure()
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Black
         shell: bash

--- a/tests/internal/e2e/README.md
+++ b/tests/internal/e2e/README.md
@@ -58,6 +58,28 @@ If behind a corporate proxy: Make sure to set `NODE_EXTRA_CA_CERTS` to point to 
 
     Code for end-to-end tests can be found under `internal/e2e/test/specs/vcast.test.ts`. The tests are specified using `Mocha` framework.
 
+#### Grouping tests:
+Tests are conceptually divided in independent groups. The `specs` can be found under `internal/e2e/test/specs_config.ts`. Whenever you want to add a new test or a new group of tests, add it there.
+Groups are defined in the `specGroups` variable in the `getSpecGroups` function, and they are made like this:
+```
+"<group-name>": [
+  <list-of-test.ts-files>
+]
+```
+There are also special groups that run only if testing vcast 24 (ATG features).
+
+Normally all groups are run. In case you want to run a single group, you need to set the following environment variables:
+```
+RUN_BY_GROUP: "True"
+RUN_GROUP_NAME: <group-name>
+```
+To test the ATG features (available with vcast24 only), you'll need this environment variable:
+```
+ENABLE_ATG_FEATURE=TRUE
+```
+
+Please note that groups represent tests for certain features and test files within them depend on each other.
+
 ### Viewing test results:
     
 - Each test step is logged to standard output. 

--- a/tests/internal/e2e/test/get_gha_matrix.ts
+++ b/tests/internal/e2e/test/get_gha_matrix.ts
@@ -1,0 +1,20 @@
+import * as fs from 'fs';
+import { getSpecGroups } from './specs_config';
+
+
+function dumpGhaMatrix() {
+    const versions = [23, 24];
+    const result: { version: number, group: string }[] = [];
+
+    versions.forEach(version => {
+        const vcast24 = version === 24
+        const specs = getSpecGroups(vcast24);
+        Object.keys(specs).forEach(group => {
+            result.push({ version, group });
+        });
+    });
+
+    fs.writeFileSync('gha_matrix.json', JSON.stringify(result));
+};
+
+const groups = dumpGhaMatrix();

--- a/tests/internal/e2e/test/specs_config.ts
+++ b/tests/internal/e2e/test/specs_config.ts
@@ -1,0 +1,63 @@
+export function getSpecGroups(vcast24: boolean) {
+    const specGroups = {
+      "basic_user_interactions": [
+          "./**/**/vcast.build_env.test.ts",
+          "./**/**/vcast.create_script_1.test.ts",
+          "./**/**/vcast.create_script_2_and_run.test.ts",
+          "./**/**/vcast.create_second_test_1.test.ts",
+          "./**/**/vcast.create_second_test_2_and_run.test.ts",
+          "./**/**/vcast.third_test.test.ts",
+          "./**/**/vcast.rest.test.ts",
+          "./**/**/vcast.rest_2.test.ts",
+          "./**/**/vcast.rest_3.test.ts",
+        ].concat(vcast24 ? ["./**/**/vcast_coded_tests.test.ts"] : []),
+      "bugs": [
+          "./**/**/vcast_testgen_bugs.test.ts",
+          "./**/**/vcast_testgen_bugs_2.test.ts",
+        ],
+      "flask_icon": [
+          "./**/**/vcast_testgen_flask_icon.test.ts",
+        ],
+      "func_basis": [
+          "./**/**/vcast_testgen_func_basis.test.ts",
+          "./**/**/vcast_testdel_func_basis.test.ts",
+        ],
+      "unit_basis": [
+          "./**/**/vcast_testgen_unit_basis.test.ts",
+          "./**/**/vcast_testdel_unit_basis.test.ts",
+        ],
+      "env_basis": [
+          "./**/**/vcast_testgen_env_basis.test.ts",
+          "./**/**/vcast_testdel_env_basis.test.ts"
+        ],
+    };
+
+    if (vcast24) {
+      specGroups["func_atg"] = [
+        "./**/**/vcast_testgen_func_atg.test.ts",
+        "./**/**/vcast_testdel_func_atg.test.ts",
+      ];
+
+      specGroups["unit_atg"] = [
+        "./**/**/vcast_testgen_unit_atg.test.ts",
+        "./**/**/vcast_testdel_unit_atg.test.ts",
+      ];
+
+      specGroups["env_atg"] = [
+        "./**/**/vcast_testgen_env_atg.test.ts",
+        "./**/**/vcast_testdel_env_atg.test.ts"
+      ];
+    }
+
+    return specGroups;
+}
+
+
+export function getSpecs(vcast24: boolean, group: string = null) {
+    const specGroups = getSpecGroups(vcast24);
+
+    if (group != null) {
+        return specGroups[group] || [];
+    }
+    return Object.values(specGroups).flat();
+};

--- a/tests/internal/e2e/test/specs_config.ts
+++ b/tests/internal/e2e/test/specs_config.ts
@@ -10,7 +10,7 @@ export function getSpecGroups(vcast24: boolean) {
           "./**/**/vcast.rest.test.ts",
           "./**/**/vcast.rest_2.test.ts",
           "./**/**/vcast.rest_3.test.ts",
-        ].concat(vcast24 ? ["./**/**/vcast_coded_tests.test.ts"] : []),
+        ],
       "bugs": [
           "./**/**/vcast_testgen_bugs.test.ts",
           "./**/**/vcast_testgen_bugs_2.test.ts",
@@ -46,6 +46,10 @@ export function getSpecGroups(vcast24: boolean) {
       specGroups["env_atg"] = [
         "./**/**/vcast_testgen_env_atg.test.ts",
         "./**/**/vcast_testdel_env_atg.test.ts"
+      ];
+
+      specGroups["coded_tests"] = [
+        "./**/**/vcast_coded_tests.test.ts"
       ];
     }
 

--- a/tests/internal/e2e/test/wdio.conf.ts
+++ b/tests/internal/e2e/test/wdio.conf.ts
@@ -75,61 +75,8 @@ const proxyObject: ProxyObject = {
   noProxy: noProxyRules,
 };
 
-const coreTestSpecs = [
-  "./**/**/vcast.build_env.test.ts",
-  "./**/**/vcast.create_script_1.test.ts",
-  "./**/**/vcast.create_script_2_and_run.test.ts",
-  "./**/**/vcast.create_second_test_1.test.ts",
-  "./**/**/vcast.create_second_test_2_and_run.test.ts",
-  "./**/**/vcast.third_test.test.ts",
-  "./**/**/vcast.rest.test.ts",
-  "./**/**/vcast.rest_2.test.ts",
-  "./**/**/vcast.rest_3.test.ts",
-];
-let fullTestSpecs = coreTestSpecs;
-if (process.env.USE_VCAST_24 == "True")
-  fullTestSpecs = coreTestSpecs.concat(["./**/**/vcast_coded_tests.test.ts"]);
-
-fullTestSpecs = fullTestSpecs.concat([
-  "./**/**/vcast_testgen_bugs.test.ts",
-  "./**/**/vcast_testgen_bugs_2.test.ts",
-]);
-
-fullTestSpecs = fullTestSpecs.concat([
-  "./**/**/vcast_testgen_flask_icon.test.ts",
-]);
-
-fullTestSpecs = fullTestSpecs.concat([
-  "./**/**/vcast_testgen_func_basis.test.ts",
-  "./**/**/vcast_testdel_func_basis.test.ts",
-]);
-
-fullTestSpecs = fullTestSpecs.concat([
-  "./**/**/vcast_testgen_unit_basis.test.ts",
-  "./**/**/vcast_testdel_unit_basis.test.ts",
-]);
-
-fullTestSpecs = fullTestSpecs.concat([
-  "./**/**/vcast_testgen_env_basis.test.ts",
-  "./**/**/vcast_testdel_env_basis.test.ts",
-]);
-
-if (process.env.USE_VCAST_24 == "True") {
-  fullTestSpecs = fullTestSpecs.concat([
-    "./**/**/vcast_testgen_func_atg.test.ts",
-    "./**/**/vcast_testdel_func_atg.test.ts",
-  ]);
-
-  fullTestSpecs = fullTestSpecs.concat([
-    "./**/**/vcast_testgen_unit_atg.test.ts",
-    "./**/**/vcast_testdel_unit_atg.test.ts",
-  ]);
-
-  fullTestSpecs = fullTestSpecs.concat([
-    "./**/**/vcast_testgen_env_atg.test.ts",
-    "./**/**/vcast_testdel_env_atg.test.ts",
-  ]);
-}
+import { getSpecs } from './specs_config.ts';
+const groupName = process.env["RUN_BY_GROUP"] === 'True' ? process.env["RUN_GROUP_NAME"] : null;
 
 export const config: Options.Testrunner = {
   //
@@ -181,7 +128,7 @@ export const config: Options.Testrunner = {
   // then the current working directory is where your `package.json` resides, so `wdio`
   // will be called from there.
   //
-  specs: fullTestSpecs,
+  specs: getSpecs(process.env["USE_VCAST_24"] === 'True', groupName),
   // Patterns to exclude.
   // exclude:
   //


### PR DESCRIPTION
We are dividing the e2e tests specs into independent groups, allowing the Github Actions workflow to retrieve all the groups and run several combinations of vcastVersion-group in parallel, saving a big amount of time.