### PR TITLE
Run tsc before running vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -603,7 +603,7 @@
     "esbuild": "npm run esbuild-base -- --sourcemap && npm run esbuild-server -- --sourcemap",
     "package": "vsce package",
     "publish": "vsce publish",
-    "test": "vitest run --reporter verbose --coverage",
+    "test": "tsc --project tsconfig_test.json && vitest run --reporter verbose --coverage",
     "gh-test": "vitest run --reporter=junit --outputFile=./test-output.xml --coverage"
   },
   "devDependencies": {

--- a/tests/unit/setup-unit-test.ts
+++ b/tests/unit/setup-unit-test.ts
@@ -119,7 +119,7 @@ module.exports = async () => {
   const tstFilePath = path.join(vcastEnvPath, tstFilename);
   const createTstFile = `echo -- Environment: TEST > ${tstFilePath}`;
   {
-    const stderr: string = await promisifiedExec(createTstFile)[1];
+    const stderr: string = (await promisifiedExec(createTstFile)).stderr;
     if (stderr) {
       console.log(stderr);
       throw new Error(`Error when running ${createTstFile}`);

--- a/tsconfig_test.json
+++ b/tsconfig_test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "esModuleInterop": true
+  },
+  "include": ["tests/unit/*.ts"]
+}


### PR DESCRIPTION
Tests are now type-checked with `tsc` before running `vitest`.

In the coded_mock branch, we would have received:

```
tests/unit/utils.ts:135:31 - error TS2345: Argument of type 'TextDocuments' is not assignable to parameter of type 'TextDocument'.
  Type 'TextDocuments' is missing the following properties from type 'TextDocument': uri, languageId, version, getText, and 3 more.

135   return getTstCompletionData(documents, completion);
```

and the tests wouldn't have run.