### PR TITLE
Fix tsc error

### DIFF
--- a/src/editorDecorator.ts
+++ b/src/editorDecorator.ts
@@ -86,11 +86,14 @@ export function buildTestNodeForFunction(args: any): testNodeType | undefined {
     const functionName = unitData.lineMap.get(args.lineNumber);
     if (functionName) {
       testNode = {
+        enviroNodeID: "",
         enviroPath: unitData.enviroPath,
         enviroName: unitData.enviroName,
         unitName: unitData.unitName,
         functionName: functionName,
         testName: "",
+        testFile: "",
+        testStartLine: 0,
       };
     }
   }


### PR DESCRIPTION
Fix the following:

```
src/editorDecorator.ts:88:7 - error TS2739: Type '{ enviroPath: string; enviroName: string; unitName: string; functionName: string; testName: string; }' is missing the following properties from type 'testNodeType': enviroNodeID, testFile, testStartLine

88       testNode = {
         ~~~~~~~~


Found 1 error in src/editorDecorator.ts:88
```
