### PR TITLE
Run tsc before package

### DIFF
--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -59,7 +59,7 @@ jobs:
           key: ${{ runner.os }}-dependencies-${{ hashFiles('package.json') }}
 
       - name: Package with VSCE
-        run: vsce package
+        run: npm run package
 
       - name: Run unit tests
         run: npm run gh-test | tee output.txt
@@ -225,7 +225,7 @@ jobs:
           key: ${{ runner.os }}-dependencies-${{ hashFiles('package.json') }}
 
       - name: Package with VSCE
-        run: vsce package
+        run: npm run package
 
       - name: Restore cached dependencies - node
         id: cache-dependencies-restore-node

--- a/README.md
+++ b/README.md
@@ -279,12 +279,12 @@ This extension is open-source, released under the MIT license, and we welcome yo
 - To install the dependencies necessary for building VectorCAST Test Explorer, run `npm install` in the root of the repository.
 - Make sure you have `vsce` installed globally
   - To install `vsce`, run `npm install -g @vscode/vsce@^2.15.0`
-- To build VectorCAST Test Explorer, run `vsce package` in the root of the repository
+- To build VectorCAST Test Explorer, run `npm run package` in the root of the repository
 - To run existing unit tests for VectorCAST Test Explorer, run `npm test` in the root of the repository
   - Code and resources for unit tests can be found in `tests/unit`
 - To run end-to-end tests (the end-to-end tests are meant for Vector internal usage):
   - If behind a corporate proxy, point `NODE_EXTRA_CA_CERTS` to your certificate bundle
-  - Make sure you had built the extension already (run `vsce package` to build the extension)
+  - Make sure you had built the extension already (run `npm run package` to build the extension)
   - Run `npm install` in `tests/internal/e2e` to install necessary dependencies
   - Run `npm test` in `tests/internal/e2e` to run the end-to-end tests
   - More detailed instructions can be found in `tests/internal/e2e`

--- a/package.json
+++ b/package.json
@@ -601,7 +601,7 @@
     "esbuild-server": "esbuild ./server/server.ts --bundle --outfile=out/server.js --external:vscode --format=cjs --platform=node",
     "esbuild-watch": "npm-run-all --parallel esbuild-base esbuild-server -- --sourcemap --watch",
     "esbuild": "npm run esbuild-base -- --sourcemap && npm run esbuild-server -- --sourcemap",
-    "package": "vsce package",
+    "package": "tsc --project tsconfig.json && vsce package",
     "publish": "vsce publish",
     "test": "vitest run --reporter verbose --coverage",
     "gh-test": "vitest run --reporter=junit --outputFile=./test-output.xml --coverage"

--- a/tests/internal/e2e/README.md
+++ b/tests/internal/e2e/README.md
@@ -46,7 +46,7 @@ If behind a corporate proxy: Make sure to set `NODE_EXTRA_CA_CERTS` to point to 
     Install npm dependencies by running `npm install` inside `internal/e2e` folder
 
 2) 
-    Make sure the extension is built by running `vsce package` in the root of the repository
+    Make sure the extension is built by running `npm run package` in the root of the repository
    
     The build script will create `vectorcasttestexplorer-<version>.vsix`, as well as `out/extension.js` and `out/server.js`. End-to-end tests are run directly on `out/extension.js` and `out/server.js`, together with necessary resources like `.svg` files.
 


### PR DESCRIPTION
This PR adds `tsc` to be run before `npm run package` (and `vsce package` should no longer be used directly).