### PR TITLE
Fix xo warning in test

### DIFF
--- a/tests/unit/setup-unit-test.ts
+++ b/tests/unit/setup-unit-test.ts
@@ -119,7 +119,7 @@ module.exports = async () => {
   const tstFilePath = path.join(vcastEnvPath, tstFilename);
   const createTstFile = `echo -- Environment: TEST > ${tstFilePath}`;
   {
-    const { stderr: stderr } = await promisifiedExec(createTstFile);
+    const { stderr } = await promisifiedExec(createTstFile);
     if (stderr) {
       console.log(stderr);
       throw new Error(`Error when running ${createTstFile}`);

--- a/tests/unit/setup-unit-test.ts
+++ b/tests/unit/setup-unit-test.ts
@@ -119,7 +119,7 @@ module.exports = async () => {
   const tstFilePath = path.join(vcastEnvPath, tstFilename);
   const createTstFile = `echo -- Environment: TEST > ${tstFilePath}`;
   {
-    const {stderr: stderr} = (await promisifiedExec(createTstFile));
+    const { stderr: stderr } = await promisifiedExec(createTstFile);
     if (stderr) {
       console.log(stderr);
       throw new Error(`Error when running ${createTstFile}`);

--- a/tests/unit/setup-unit-test.ts
+++ b/tests/unit/setup-unit-test.ts
@@ -119,7 +119,7 @@ module.exports = async () => {
   const tstFilePath = path.join(vcastEnvPath, tstFilename);
   const createTstFile = `echo -- Environment: TEST > ${tstFilePath}`;
   {
-    const stderr: string = (await promisifiedExec(createTstFile)).stderr;
+    const {stderr: stderr} = (await promisifiedExec(createTstFile));
     if (stderr) {
       console.log(stderr);
       throw new Error(`Error when running ${createTstFile}`);


### PR DESCRIPTION
Fixes the following `xo` warning:

```
  tests/unit/setup-unit-test.ts:122:67
  ✖  122:67  Do not access a member directly from an await expression.  unicorn/no-await-expression-member
```
