### PR TITLE
Vc24__101394_store_mock_info version for CI

### DIFF
--- a/docker/Ubuntu24-Dockerfile-CI
+++ b/docker/Ubuntu24-Dockerfile-CI
@@ -62,21 +62,6 @@ RUN sudo apt-get update && sudo apt-get install -y libcurl4-openssl-dev libexpat
 
 SHELL ["/bin/bash", "--login", "-c"]
 
-ADD https://rds-vtc-docker-dev-local.vegistry.vg.vector.int:443/artifactory/rds-build-packages-generic-dev/vcast_test_explorer/vcast.linux64.2023.tar.gz /vcast/releaseVectorCAST23.tar.gz
-ADD https://rds-vtc-docker-dev-local.vegistry.vg.vector.int:443/artifactory/rds-build-packages-generic-dev/vcast_test_explorer/vcast.linux64.2024sp3.tar.gz /vcast/releaseVectorCAST24.tar.gz
-ADD https://rds-vtc-docker-dev-local.vegistry.vg.vector.int:443/artifactory/rds-build-packages-generic-dev-local/vcast_test_explorer/vector-DEMO-2025.lic /vcast/vector-license.lic
-
-RUN sudo chown -R $(id -u $USERNAME):$(id -g $USERNAME) /vcast
-
-RUN cd /vcast && \
-    tar -xvzf releaseVectorCAST23.tar.gz && rm releaseVectorCAST23.tar.gz && mv vcast release23 && \
-    tar -xvzf releaseVectorCAST24.tar.gz && rm releaseVectorCAST24.tar.gz && mv vcast release24
-
-ENV VECTORCAST_DIR=/vcast/release23 \
-    PATH=/vcast/release23:$PATH \
-    LM_LICENSE_FILE=/vcast/vector-license.lic \
-    VECTOR_LICENSE_FILE=/vcast/vector-license.lic
-
 RUN sudo apt-get update && \
     sudo apt-get install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev && \
     sudo apt-get update && sudo apt-get install -y libasound2-dev && \
@@ -87,6 +72,21 @@ RUN sudo apt-get update && \
 ENV TESTING_IN_CONTAINER=True \
     RUNNING_ON_SERVER=False \
     PIP_CONFIG_FILE=/home/${USERNAME}/.pip/pip.conf
+
+ADD https://rds-vtc-docker-dev-local.vegistry.vg.vector.int:443/artifactory/rds-build-packages-generic-dev/vcast_test_explorer/vcast.linux64.2023.tar.gz /vcast/releaseVectorCAST23.tar.gz
+ADD https://rds-vtc-docker-dev-local.vegistry.vg.vector.int/artifactory/rds-build-packages-generic-dev/vcast_test_explorer/vc24__101394_store_mock_info.tar.gz /vcast/vc24__101394_store_mock_info.tar.gz
+ADD https://rds-vtc-docker-dev-local.vegistry.vg.vector.int:443/artifactory/rds-build-packages-generic-dev-local/vcast_test_explorer/vector-DEMO-2025.lic /vcast/vector-license.lic
+
+RUN sudo chown -R $(id -u $USERNAME):$(id -g $USERNAME) /vcast
+
+RUN cd /vcast && \
+    tar -xvzf releaseVectorCAST23.tar.gz && rm releaseVectorCAST23.tar.gz && mv vcast release23 && \
+    tar -xvzf vc24__101394_store_mock_info.tar.gz && rm vc24__101394_store_mock_info.tar.gz && mv release release24
+
+ENV VECTORCAST_DIR=/vcast/release23 \
+    PATH=/vcast/release23:$PATH \
+    LM_LICENSE_FILE=/vcast/vector-license.lic \
+    VECTOR_LICENSE_FILE=/vcast/vector-license.lic
 
 RUN sudo mkdir -m 1777 /__w && sudo chown -R $(id -u $USERNAME):$(id -g $USERNAME) /__w
 


### PR DESCRIPTION
We are switching to Vc24__101394_store_mock_info for Vcast 24 in the CI container