### PR TITLE
Clean-up for the case when we're run with a version of VectorCAST that doesn't support coded mocks

### DIFF
--- a/python/tstUtilities.py
+++ b/python/tstUtilities.py
@@ -15,7 +15,31 @@ from enum import Enum
 
 from vector.apps.DataAPI.unit_test_api import UnitTestApi
 from vector.apps.DataAPI.unit_test_models import Function, Global
-from vector.apps.DataAPI import mock_helper
+
+coded_mocks_enabled = False
+try:
+    from vector.apps.DataAPI import mock_helper
+
+    # NOTE: we don't need to check if an environment supports coded mocks, only
+    # a version of _VectorCAST_.
+    #
+    # If an environment doesn't have coded tests enabled (or it was originally
+    # build with a version of VectorCAST that did not support coded tests/coded
+    # mocks) and we open it up with a version of VectorCAST with `mock_helper`,
+    # then `.mock.` will be set to `None`.
+    #
+    # We also need to check that the verison of the api in `mock_helper` is
+    # compatible with this version of the extension.
+
+    # The version of the api this version of the extension supports
+    supported_mock_api_version = 1
+
+    # We only enable coded mocks if the version of `mock_helper` is <= than our
+    # supported version
+    coded_mocks_enabled = mock_helper.MOCK_API_MAJOR <= supported_mock_api_version
+
+except ImportError:
+    pass
 
 from vConstants import (
     TAG_FOR_INIT,
@@ -35,7 +59,9 @@ ADD_HASH_TO_MOCK_FUNCTION_NAMES = False
 
 
 def functionCanBeMocked(functionObject):
-    return hasattr(functionObject, "mock") and functionObject.mock is not None
+    # NOTE: this function should *only* be called when 'coded_mocks_enabled' is
+    # set to true
+    return functionObject.mock is not None
 
 
 def generateMockEnableForUnitAndFunction(functionObject, mockFunctionName):
@@ -599,8 +625,8 @@ def getUnitAndFunctionObjects(api, unitString, functionString):
             elif unitObject.name.startswith(unitString):
                 returnUnitList.append(unitObject)
 
-    # if the unit name is an exact match, process the function name
-    if len(returnUnitList) == 1:
+    # if coded mocks are enabled, and the unit name is an exact match, process the function name
+    if coded_mocks_enabled and len(returnUnitList) == 1:
         # check if the function name matches any of the functions in the unit
         for functionObject in unitObject.functions:
             if functionCanBeMocked(functionObject):

--- a/python/vmockGenerator.py
+++ b/python/vmockGenerator.py
@@ -80,9 +80,6 @@ def generateAllVMockDefinitions(api):
             mock_bodies.append(f"{mock_definition}")
             mock_usages.append(mock_data.enableFunctionCall)
 
-    # Don't run this on a file with no units
-    assert first_unit is not None
-
     return first_unit, mock_bodies, mock_usages
 
 
@@ -180,6 +177,11 @@ def generate_tests_for_environment(enviro_path):
 
     # Generate our coded test ...
     first_unit = generate_test_file(api)
+
+    if first_unit is None:
+        print("No unit found (migrated VectorCAST environment?)")
+        return -1
+
     # ... and the test script to load the coded test
     generate_test_script(api.environment.name, first_unit)
 


### PR DESCRIPTION
This PR changes our Python files such that they are "more protective" about when they try to do coded mock work on an environment that doesn't support mocks.

Tested with:

- 2023 (option not in CFG) -> `This version of VectorCAST does not support coded mocks`
- 2024sp3 (coded mocks disabled) -> `This version of VectorCAST does not support coded mocks`
- 2024sp3 (coded mocks enabled) -> `This version of VectorCAST does not support coded mocks`
- 2023 (option not in CFG), opened with vc24__101394_store_mock_info -> `Coded tests are not enabled on this environment`
- 2024sp3 (coded mocks disabled), opened with vc24__101394_store_mock_info -> `Coded tests are not enabled on this environment`
- 2024sp3 (coded mocks enabled), opened with vc24__101394_store_mock_info -> `No unit found (migrated VectorCAST environment?)`