### PR TITLE
Added E2E for #114

### DIFF
--- a/tests/internal/e2e/test/specs/vcast_coded_tests_relative_path.test.ts
+++ b/tests/internal/e2e/test/specs/vcast_coded_tests_relative_path.test.ts
@@ -1,0 +1,245 @@
+// Test/specs/vcast.test.ts
+import {
+  type BottomBarPanel,
+  type TextEditor,
+  type Workbench,
+  type TreeItem,
+} from "wdio-vscode-service";
+import { Key } from "webdriverio";
+import {
+  getViewContent,
+  findSubprogram,
+  findSubprogramMethod,
+  openTestScriptFor,
+  updateTestID,
+  expandWorkspaceFolderSectionInExplorer,
+  executeCtrlClickOn,
+  releaseCtrl,
+  getTestHandle,
+} from "../test_utils/vcast_utils";
+
+describe("vTypeCheck VS Code Extension", () => {
+  let bottomBar: BottomBarPanel;
+  let workbench: Workbench;
+  const TIMEOUT = 20_000;
+  before(async () => {
+    workbench = await browser.getWorkbench();
+    // Opening bottom bar and problems view before running any tests
+    bottomBar = workbench.getBottomBar();
+    await bottomBar.toggle(true);
+    process.env.E2E_TEST_ID = "0";
+  });
+
+  it("test 1: should be able to load VS Code", async () => {
+    await updateTestID();
+    expect(await workbench.getTitleBar().getTitle()).toBe(
+      "[Extension Development Host] vcastTutorial - Visual Studio Code"
+    );
+  });
+
+  it("should activate vcastAdapter", async () => {
+    await updateTestID();
+
+    await browser.keys([Key.Control, Key.Shift, "p"]);
+    // Typing Vector in the quick input box
+    // This brings up VectorCAST Test Explorer: Configure
+    // so just need to hit Enter to activate
+    for (const character of "vector") {
+      await browser.keys(character);
+    }
+
+    await browser.keys(Key.Enter);
+
+    const activityBar = workbench.getActivityBar();
+    const viewControls = await activityBar.getViewControls();
+    for (const viewControl of viewControls) {
+      console.log(await viewControl.getTitle());
+    }
+
+    await bottomBar.toggle(true);
+    const outputView = await bottomBar.openOutputView();
+
+    console.log("Waiting for VectorCAST activation");
+    await $("aria/VectorCAST Test Pane Initialization");
+    console.log("WAITING FOR TESTING");
+    await browser.waitUntil(
+      async () => (await activityBar.getViewControl("Testing")) !== undefined,
+      { timeout: TIMEOUT }
+    );
+    console.log("WAITING FOR TEST EXPLORER");
+    await browser.waitUntil(async () =>
+      (await outputView.getChannelNames())
+        .toString()
+        .includes("VectorCAST Test Explorer")
+    );
+    await outputView.selectChannel("VectorCAST Test Explorer");
+    console.log("Channel selected");
+    console.log("WAITING FOR LANGUAGE SERVER");
+    await browser.waitUntil(
+      async () =>
+        (await outputView.getText())
+          .toString()
+          .includes("Starting the language server"),
+      { timeout: TIMEOUT }
+    );
+
+    const testingView = await activityBar.getViewControl("Testing");
+    await testingView?.openView();
+  });
+
+  it("should set default config file", async () => {
+    await updateTestID();
+
+    const workbench = await browser.getWorkbench();
+    const activityBar = workbench.getActivityBar();
+    const explorerView = await activityBar.getViewControl("Explorer");
+    await explorerView?.openView();
+
+    const workspaceFolderSection =
+      await expandWorkspaceFolderSectionInExplorer("vcastTutorial");
+
+    const configFile = await workspaceFolderSection.findItem("CCAST_.CFG");
+    await configFile.openContextMenu();
+    await (await $("aria/Set as VectorCAST Configuration File")).click();
+  });
+
+  // it("should create VectorCAST environment", async () => {
+  //   await updateTestID();
+
+  //   const workbench = await browser.getWorkbench();
+  //   const activityBar = workbench.getActivityBar();
+  //   const explorerView = await activityBar.getViewControl("Explorer");
+  //   await explorerView?.openView();
+
+  //   const workspaceFolderSection =
+  //     await expandWorkspaceFolderSectionInExplorer("vcastTutorial");
+  //   const cppFolder = workspaceFolderSection.findItem("cpp");
+  //   await (await cppFolder).select();
+
+  //   const managerCpp = await workspaceFolderSection.findItem("manager.cpp");
+  //   const databaseCpp = await workspaceFolderSection.findItem("database.cpp");
+  //   await executeCtrlClickOn(databaseCpp);
+  //   await executeCtrlClickOn(managerCpp);
+  //   await releaseCtrl();
+
+  //   await databaseCpp.openContextMenu();
+  //   await (await $("aria/Create VectorCAST Environment")).click();
+
+  //   // Making sure notifications are shown
+  //   await (await $("aria/Notifications")).click();
+
+  //   // This will timeout if VectorCAST notification does not appear, resulting in a failed test
+  //   const vcastNotificationSourceElement = await $(
+  //     "aria/VectorCAST Test Explorer (Extension)"
+  //   );
+  //   const vcastNotification = await vcastNotificationSourceElement.$("..");
+  //   await (await vcastNotification.$("aria/Yes")).click();
+
+  //   console.log(
+  //     "Waiting for clicast and waiting for environment to get processed"
+  //   );
+  //   await browser.waitUntil(
+  //     async () =>
+  //       (await (await bottomBar.openOutputView()).getText())
+  //         .toString()
+  //         .includes("Environment built Successfully"),
+  //     { timeout: TIMEOUT }
+  //   );
+
+  //   console.log("Finished creating vcast environment");
+  //   await browser.takeScreenshot();
+  //   await browser.saveScreenshot(
+  //     "info_finished_creating_vcast_environment.png"
+  //   );
+  //   // Clearing all notifications
+  //   await (await $(".codicon-notifications-clear-all")).click();
+  // });
+
+  it("should enable coded test", async () => {
+    await updateTestID();
+
+    const workbench = await browser.getWorkbench();
+    const settingsEditor = await workbench.openSettings();
+    console.log("Looking for coded tests settings");
+    await settingsEditor.findSetting(
+      "vectorcastTestExplorer.enableCodedTesting"
+    );
+    // Only one setting in search results, so the current way of clicking is correct
+    console.log("Enabling coded tests");
+    await (await settingsEditor.checkboxSetting$).click();
+    await workbench.getEditorView().closeAllEditors();
+  });
+
+  it("should check for vmock code completion", async () => {
+    // Update test ID for traceability
+    await updateTestID();
+
+    // Open the "Testing" view and log the action
+    console.log("Opening Testing View");
+    const vcastTestingViewContent = await getViewContent("Testing");
+
+    let subprogram: TreeItem;
+    let testHandle: TreeItem;
+
+    // Iterate over sections to find the "moo" subprogram and expand it
+    for (const section of await vcastTestingViewContent.getSections()) {
+      subprogram = await findSubprogram("moo", section);
+      if (subprogram) {
+        // Expand the subprogram if it's not already expanded
+        if (!(await subprogram.isExpanded())) await subprogram.expand();
+        console.log("Getting test handle");
+
+        // Get the test handle for the specified test case
+        testHandle = await getTestHandle(
+          subprogram,
+          "Coded Tests",
+          "mooTests.ExampleTestCase",
+          1
+        );
+
+        // Break out of the loop if the test handle is found, otherwise throw an error
+        if (testHandle) break;
+        throw new Error("Test handle not found for mooTests.ExampleTestCase");
+      }
+    }
+
+    // Ensure the test handle is not undefined
+    expect(testHandle).not.toBe(undefined);
+
+    // Open context menu and select "VectorCAST"
+    let contextMenu = await testHandle.openContextMenu();
+    await contextMenu.select("VectorCAST");
+
+    // Click on "Edit Coded Test" from the menu
+    let menuElement = await $("aria/Edit Coded Test");
+    await menuElement.click();
+
+    // Wait until the "tests.cpp" tab is active in the editor view
+    const editorView = workbench.getEditorView();
+    await browser.waitUntil(
+      async () =>
+        (await (await editorView.getActiveTab()).getTitle()) === "tests.cpp"
+    );
+
+    // Open the "tests.cpp" file in the editor and trigger code completion
+    const tab = (await editorView.openEditor("tests.cpp")) as TextEditor;
+    await browser.keys([Key.Ctrl, Key.Space]);
+
+    const contentAssist = await tab.toggleContentAssist(true);
+    // Just do some autocompletion to see if we can edit the Coded Test
+    await tab.setTextAtLine(14, "// vmock");
+    let currentLine = await tab.getLineOfText("// vmock");
+    await tab.typeTextAt(currentLine, "// vmock".length + 1, " ");
+    await tab.save();
+    await browser.waitUntil(
+      async () => (await contentAssist.getItems()).length > 0
+    );
+
+    // Validating content assist for '// vmock'
+    const expectedItems = ["moo", "Prototype-Stubs"];
+
+    for (const item of expectedItems) {
+      expect(await contentAssist.hasItem(item)).toBe(true);
+    }
+  });
+});

--- a/tests/internal/e2e/test/specs/vcast_coded_tests_relative_path.test.ts
+++ b/tests/internal/e2e/test/specs/vcast_coded_tests_relative_path.test.ts
@@ -9,12 +9,8 @@ import { Key } from "webdriverio";
 import {
   getViewContent,
   findSubprogram,
-  findSubprogramMethod,
-  openTestScriptFor,
   updateTestID,
   expandWorkspaceFolderSectionInExplorer,
-  executeCtrlClickOn,
-  releaseCtrl,
   getTestHandle,
 } from "../test_utils/vcast_utils";
 
@@ -103,58 +99,6 @@ describe("vTypeCheck VS Code Extension", () => {
     await (await $("aria/Set as VectorCAST Configuration File")).click();
   });
 
-  // it("should create VectorCAST environment", async () => {
-  //   await updateTestID();
-
-  //   const workbench = await browser.getWorkbench();
-  //   const activityBar = workbench.getActivityBar();
-  //   const explorerView = await activityBar.getViewControl("Explorer");
-  //   await explorerView?.openView();
-
-  //   const workspaceFolderSection =
-  //     await expandWorkspaceFolderSectionInExplorer("vcastTutorial");
-  //   const cppFolder = workspaceFolderSection.findItem("cpp");
-  //   await (await cppFolder).select();
-
-  //   const managerCpp = await workspaceFolderSection.findItem("manager.cpp");
-  //   const databaseCpp = await workspaceFolderSection.findItem("database.cpp");
-  //   await executeCtrlClickOn(databaseCpp);
-  //   await executeCtrlClickOn(managerCpp);
-  //   await releaseCtrl();
-
-  //   await databaseCpp.openContextMenu();
-  //   await (await $("aria/Create VectorCAST Environment")).click();
-
-  //   // Making sure notifications are shown
-  //   await (await $("aria/Notifications")).click();
-
-  //   // This will timeout if VectorCAST notification does not appear, resulting in a failed test
-  //   const vcastNotificationSourceElement = await $(
-  //     "aria/VectorCAST Test Explorer (Extension)"
-  //   );
-  //   const vcastNotification = await vcastNotificationSourceElement.$("..");
-  //   await (await vcastNotification.$("aria/Yes")).click();
-
-  //   console.log(
-  //     "Waiting for clicast and waiting for environment to get processed"
-  //   );
-  //   await browser.waitUntil(
-  //     async () =>
-  //       (await (await bottomBar.openOutputView()).getText())
-  //         .toString()
-  //         .includes("Environment built Successfully"),
-  //     { timeout: TIMEOUT }
-  //   );
-
-  //   console.log("Finished creating vcast environment");
-  //   await browser.takeScreenshot();
-  //   await browser.saveScreenshot(
-  //     "info_finished_creating_vcast_environment.png"
-  //   );
-  //   // Clearing all notifications
-  //   await (await $(".codicon-notifications-clear-all")).click();
-  // });
-
   it("should enable coded test", async () => {
     await updateTestID();
 
@@ -171,10 +115,8 @@ describe("vTypeCheck VS Code Extension", () => {
   });
 
   it("should check for vmock code completion", async () => {
-    // Update test ID for traceability
     await updateTestID();
 
-    // Open the "Testing" view and log the action
     console.log("Opening Testing View");
     const vcastTestingViewContent = await getViewContent("Testing");
 
@@ -189,7 +131,6 @@ describe("vTypeCheck VS Code Extension", () => {
         if (!(await subprogram.isExpanded())) await subprogram.expand();
         console.log("Getting test handle");
 
-        // Get the test handle for the specified test case
         testHandle = await getTestHandle(
           subprogram,
           "Coded Tests",
@@ -197,20 +138,16 @@ describe("vTypeCheck VS Code Extension", () => {
           1
         );
 
-        // Break out of the loop if the test handle is found, otherwise throw an error
         if (testHandle) break;
         throw new Error("Test handle not found for mooTests.ExampleTestCase");
       }
     }
 
-    // Ensure the test handle is not undefined
     expect(testHandle).not.toBe(undefined);
 
-    // Open context menu and select "VectorCAST"
     let contextMenu = await testHandle.openContextMenu();
     await contextMenu.select("VectorCAST");
 
-    // Click on "Edit Coded Test" from the menu
     let menuElement = await $("aria/Edit Coded Test");
     await menuElement.click();
 
@@ -226,6 +163,7 @@ describe("vTypeCheck VS Code Extension", () => {
     await browser.keys([Key.Ctrl, Key.Space]);
 
     const contentAssist = await tab.toggleContentAssist(true);
+
     // Just do some autocompletion to see if we can edit the Coded Test
     await tab.setTextAtLine(14, "// vmock");
     let currentLine = await tab.getLineOfText("// vmock");

--- a/tests/internal/e2e/test/specs_config.ts
+++ b/tests/internal/e2e/test/specs_config.ts
@@ -119,6 +119,12 @@ export function getSpecGroups(useVcast24: boolean) {
       env: {},
       params: {},
     };
+
+    specGroups["import_coded_test"] = {
+      specs: ["./**/**/vcast_coded_tests_relative_path.test.ts"],
+      env: { IMPORT_CODED_TEST_IN_TST: "True" },
+      params: {},
+    };
   }
 
   return specGroups;

--- a/tests/internal/e2e/test/wdio.conf.ts
+++ b/tests/internal/e2e/test/wdio.conf.ts
@@ -444,7 +444,7 @@ export const config: Options.Testrunner = {
       );
 
       let vcastRoot = await getVcastRoot();
-      const newVersion = "vc24";
+      const newVersion = "release24";
 
       // Set up environment directory
       process.env.VECTORCAST_DIR = path.join(vcastRoot, newVersion);

--- a/tests/internal/e2e/test/wdio.conf.ts
+++ b/tests/internal/e2e/test/wdio.conf.ts
@@ -335,7 +335,7 @@ export const config: Options.Testrunner = {
 
     if (envKey) {
       // Execute the corresponding function if an environment variable is found
-      await envActions.get(envKey)!();
+      await envActions.get(envKey)();
     } else {
       // Default case if no matching environment variable is found
       await setupSingleEnvironment(initialWorkdir);
@@ -426,7 +426,7 @@ export const config: Options.Testrunner = {
     }
 
     /**
-     * Builds one env with 2024sp3 and switches to vc24__101394_store_mock_info at the end.
+     * Builds one env with 2024sp3 and switches to vc24 at the end.
      * TARGET SPEC GROUP: coded_mock_different_env
      */
     async function setupSingleEnvAndImportCT(initialWorkdir: string) {
@@ -444,7 +444,7 @@ export const config: Options.Testrunner = {
       );
 
       let vcastRoot = await getVcastRoot();
-      const newVersion = "vc24__101394_store_mock_info";
+      const newVersion = "vc24";
 
       // Set up environment directory
       process.env.VECTORCAST_DIR = path.join(vcastRoot, newVersion);
@@ -456,9 +456,6 @@ export const config: Options.Testrunner = {
 
       await executeRGWCommands(testInputVcastTutorial);
       await copyPathsToTestLocation(testInputVcastTutorial);
-
-      // Log that SWITCH_ENV_AT_THE_END is being defined
-      console.log("SWITCH_ENV_AT_THE_END IS DEFINED");
 
       // Define paths and content for the necessary test files
       const unitFileContent = `void foo (void){}`;


### PR DESCRIPTION
## Summary

Added E2E for #114. 
Creating new TST that imports an coded test. Check in E2E if we can edit the coded test with `// vmock` autocompletion. 

## Added
`vcast_coded_tests_relative_path.test.ts` E2E test.
Added `import_coded_tests` spec group. 