### PR TITLE
Fixed clicast ping test

### DIFF
--- a/tests/unit/vcast-server.test.ts
+++ b/tests/unit/vcast-server.test.ts
@@ -86,6 +86,7 @@ describe("test server functions", () => {
   test("serverIsAlive handles successful response", async () => {
     const fetchReturn = {
       exitCode: 0,
+      text: "clicast-path: /some/path",
       data: {},
     };
 


### PR DESCRIPTION
## Summary

`serverIsAlive()` now requires a `text` field in the response. Since we mock the server fetch, I added a text field including `clicast-path` so that the split operation does not fail. 

https://github.com/vectorgrp/vector-vscode-vcast/blob/3d64e64ad7b1c88837de7b48c19666e102c60ac7/src-common/vcastServer.ts#L143