### PR TITLE
Changed pythonError codes to be less than 255

### DIFF
--- a/python/vcastDataServerTypes.py
+++ b/python/vcastDataServerTypes.py
@@ -7,10 +7,10 @@ PORT = 60461  # The port used by the server anything > 1023 is OK
 
 
 class errorCodes(str, Enum):
-    internalServerError = 999
-    testInterfaceError = 998
-    couldNotStartClicastInstance = 997
-    codedTestCompileError = 996
+    internalServerError = 99
+    testInterfaceError = 98
+    couldNotStartClicastInstance = 97
+    codedTestCompileError = 96
 
 
 # NOTE: This class must stay in sync with typescript file vcastServer.ts: vcastCommandType

--- a/src-common/vcastServerTypes.ts
+++ b/src-common/vcastServerTypes.ts
@@ -1,9 +1,6 @@
-
-
 export enum pythonErrorCodes {
-    internalServerError = 999,
-    testInterfaceError = 998,
-    couldNotStartClicastInstance = 997,
-    codedTestCompileError = 996
+  internalServerError = 99,
+  testInterfaceError = 98,
+  couldNotStartClicastInstance = 97,
+  codedTestCompileError = 96,
 }
-


### PR DESCRIPTION
This PR modifies the `pythonError` codes to values below `255`, ensuring they stay within the maximum return limit for C programs on Linux.

Closes #200