### PR TITLE
Status bar coverage messages improvement

### DIFF
--- a/python/vTestInterface.py
+++ b/python/vTestInterface.py
@@ -279,8 +279,8 @@ def getUnitData(api):
 
     sourceObjects = api.SourceFile.all()
     for sourceObject in sourceObjects:
+        sourcePath = sourceObject.display_path
         if sourceObject.is_instrumented:
-            sourcePath = sourceObject.display_path
             covered, uncovered, checksum = getCoverageData(sourceObject)
             unitInfo = dict()
             unitInfo["path"] = sourcePath
@@ -288,6 +288,18 @@ def getUnitData(api):
             unitInfo["cmcChecksum"] = checksum
             unitInfo["covered"] = covered
             unitInfo["uncovered"] = uncovered
+            unitList.append(unitInfo)
+
+        elif len(sourcePath) > 0:
+            # we save "empty" unit data for files that are not
+            # instrumented so that the the extension can display
+            # "No Coverage Data" for these ...
+            unitInfo = dict()
+            unitInfo["path"] = sourcePath
+            unitInfo["functionList"] = []
+            unitInfo["cmcChecksum"] = "0"
+            unitInfo["covered"] = ""
+            unitInfo["uncovered"] = ""
             unitList.append(unitInfo)
 
     return unitList

--- a/python/vTestInterface.py
+++ b/python/vTestInterface.py
@@ -73,6 +73,7 @@ def setupArgs():
 
     parser.add_argument(
         "--path",
+        required=True,
         help="Path to Environment Directory",
     )
 

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -133,7 +133,6 @@ export function updateCOVdecorations() {
       const statusBarText = `Coverage: ${covered}/${coverable} (${percentage}%)`;
       globalStatusBarObject.text = statusBarText;
       globalStatusBarObject.show();
-
     } else if (coverageData.statusString.length > 0) {
       // this handles the case where coverage is out of date (for example)
       globalStatusBarObject.text = coverageData.statusString;

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -99,7 +99,7 @@ export function updateCOVdecorations() {
     const coverageData = getCoverageDataForFile(filePath);
 
     if (coverageData.hasCoverageData) {
-      // there is data to display
+      // there is coverage data and it matches the file checksum
       // Reset the global decoration arrays
       resetGlobalDecorations();
 
@@ -125,19 +125,26 @@ export function updateCOVdecorations() {
       const covered = coveredDecorations.length;
       const coverable = covered + uncoveredDecorations.length;
       let percentage: number;
-      if (coverable == 0) percentage = 0;
-      else percentage = Math.round((covered / coverable) * 100);
+      if (coverable == 0) {
+        percentage = 0;
+      } else {
+        percentage = Math.round((covered / coverable) * 100);
+      }
       const statusBarText = `Coverage: ${covered}/${coverable} (${percentage}%)`;
       globalStatusBarObject.text = statusBarText;
       globalStatusBarObject.show();
+
     } else if (coverageData.statusString.length > 0) {
+      // this handles the case where coverage is out of date (for example)
       globalStatusBarObject.text = coverageData.statusString;
       globalStatusBarObject.show();
       resetGlobalDecorations();
     } else {
-      globalStatusBarObject.hide;
+      // we get here for C/C++ files that are not part of an environment
+      globalStatusBarObject.hide();
     }
   } else {
+    // we get here for non-C/C++ files
     globalStatusBarObject.hide();
   }
 }

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -98,10 +98,7 @@ export function updateCOVdecorations() {
     // this returns the cached coverage data for this file
     const coverageData = getCoverageDataForFile(filePath);
 
-    if (coverageData.statusString.length > 0) {
-      globalStatusBarObject.text = coverageData.statusString;
-      resetGlobalDecorations();
-    } else {
+    if (coverageData.hasCoverageData) {
       // there is data to display
       // Reset the global decoration arrays
       resetGlobalDecorations();
@@ -133,8 +130,13 @@ export function updateCOVdecorations() {
       const statusBarText = `Coverage: ${covered}/${coverable} (${percentage}%)`;
       globalStatusBarObject.text = statusBarText;
       globalStatusBarObject.show();
+    } else if (coverageData.statusString.length>0) {
+      globalStatusBarObject.text = coverageData.statusString;
+      globalStatusBarObject.show();
+      resetGlobalDecorations();
+    } else {
+      globalStatusBarObject.hide
     }
-    globalStatusBarObject.show();
   } else {
     globalStatusBarObject.hide();
   }

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -130,12 +130,12 @@ export function updateCOVdecorations() {
       const statusBarText = `Coverage: ${covered}/${coverable} (${percentage}%)`;
       globalStatusBarObject.text = statusBarText;
       globalStatusBarObject.show();
-    } else if (coverageData.statusString.length>0) {
+    } else if (coverageData.statusString.length > 0) {
       globalStatusBarObject.text = coverageData.statusString;
       globalStatusBarObject.show();
       resetGlobalDecorations();
     } else {
-      globalStatusBarObject.hide
+      globalStatusBarObject.hide;
     }
   } else {
     globalStatusBarObject.hide();

--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -147,6 +147,10 @@ function deactivateCoverage() {
   globalStatusBarObject.hide();
 }
 
+export function hideStatusBarCoverage() {
+  globalStatusBarObject.hide();
+}
+
 export function createCoverageStatusBar() {
   globalStatusBarObject = vscode.window.createStatusBarItem(
     vscode.StatusBarAlignment.Right,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -605,7 +605,7 @@ function configureExtension(context: vscode.ExtensionContext) {
   );
 
   vscode.window.onDidChangeActiveTextEditor(
-    // this function gets called when the user changes the 
+    // this function gets called when the user changes the
     // active editor, including when closing an editor
     // in which case the "editor" parameter will be undefined
     (editor) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,8 +14,9 @@ import {
 } from "./configuration";
 
 import {
-  initializeCodeCoverageFeatures,
   createCoverageStatusBar,
+  hideStatusBarCoverage,
+  initializeCodeCoverageFeatures,
   toggleCoverageAction,
   updateDisplayedCoverage,
   updateCOVdecorations,
@@ -604,10 +605,15 @@ function configureExtension(context: vscode.ExtensionContext) {
   );
 
   vscode.window.onDidChangeActiveTextEditor(
+    // this function gets called when the user changes the 
+    // active editor, including when closing an editor
+    // in which case the "editor" parameter will be undefined
     (editor) => {
       if (editor) {
         updateDisplayedCoverage();
         updateTestDecorator();
+      } else {
+        hideStatusBarCoverage();
       }
     },
     null,

--- a/src/vcastTestInterface.ts
+++ b/src/vcastTestInterface.ts
@@ -178,6 +178,7 @@ export function resetCoverageData() {
 }
 
 interface coverageSummaryType {
+  hasCoverageData: boolean;
   statusString: string;
   covered: number[];
   uncovered: number[];
@@ -197,7 +198,8 @@ export function getCoverageDataForFile(filePath: string): coverageSummaryType {
   // .statusString will be "out-of-date" if NO enviro checksums match this file
 
   let returnData: coverageSummaryType = {
-    statusString: "No Coverage Data",
+    hasCoverageData: false,
+    statusString: "",
     covered: [],
     uncovered: [],
   };
@@ -221,7 +223,7 @@ export function getCoverageDataForFile(filePath: string): coverageSummaryType {
     if (coveredList.length == 0 && uncoveredList.length == 0) {
       returnData.statusString = "Coverage Out of Date";
     } else {
-      returnData.statusString = "";
+      returnData.hasCoverageData = true;
       // remove duplicates
       returnData.covered = [...new Set(coveredList)];
       returnData.uncovered = [...new Set(uncoveredList)];

--- a/tests/internal/e2e/test/specs/vcast.create_script_2_and_run.test.ts
+++ b/tests/internal/e2e/test/specs/vcast.create_script_2_and_run.test.ts
@@ -15,6 +15,7 @@ import {
   findSubprogramMethod,
   editTestScriptFor,
   updateTestID,
+  expandWorkspaceFolderSectionInExplorer,
 } from "../test_utils/vcast_utils";
 import { TIMEOUT } from "../test_utils/vcast_utils";
 
@@ -168,6 +169,66 @@ describe("vTypeCheck VS Code Extension", () => {
     await browser.executeWorkbench((vscode) => {
       vscode.commands.executeCommand("vectorcastTestExplorer.loadTestScript");
     });
+  });
+
+  it("should verify no coverage in status bar when opening uninstrumented quotes_example.cpp. ", async () => {
+    await updateTestID();
+
+    const workbench = await browser.getWorkbench();
+    const activityBar = workbench.getActivityBar();
+    const explorerView = await activityBar.getViewControl("Explorer");
+    await explorerView?.openView();
+
+    const workspaceFolderSection =
+      await expandWorkspaceFolderSectionInExplorer("vcastTutorial");
+
+    const quotesCpp =
+      await workspaceFolderSection.findItem("quotes_example.cpp");
+    await quotesCpp.select();
+
+    statusBar = workbench.getStatusBar();
+    const statusBarInfos = await statusBar.getItems();
+
+    console.log("Verifying absence of coverage status for quotes_example.");
+
+    // Verifying that there is no coverage status for quotes_example as it is not instrumented
+    expect(statusBarInfos.includes("Coverage:")).toBe(false);
+    expect(statusBarInfos.includes("No Coverage Data")).toBe(false);
+    expect(statusBarInfos.includes("Coverage Out of Date")).toBe(false);
+  });
+
+  it("should verify no coverage in status bar after opening and closing manager.cpp. ", async () => {
+    await updateTestID();
+    const workspaceFolderSection =
+      await expandWorkspaceFolderSectionInExplorer("vcastTutorial");
+
+    const managerCpp = await workspaceFolderSection.findItem("manager.cpp");
+    await managerCpp.select();
+
+    statusBar = workbench.getStatusBar();
+
+    console.log(
+      "Verifying coverage status for manager.cpp when opened but nor run in the editor."
+    );
+
+    // Tests are not run yet, but we should get this coverage status info at the beginning
+    await browser.waitUntil(
+      async () => (await statusBar.getItems()).includes("Coverage: 0/41 (0%)"),
+      { timeout: TIMEOUT }
+    );
+
+    const statusBarInfos = await statusBar.getItems();
+
+    console.log(
+      "Verifying absence of coverage status for manager.cpp when closing the editor."
+    );
+    await editorView.closeEditor("quotes_example.cpp", 0);
+    await editorView.closeEditor("manager.cpp", 0);
+
+    // When closing the manager.cpp editor, no coverage info should be displayed
+    expect(statusBarInfos.includes("Coverage:")).toBe(false);
+    expect(statusBarInfos.includes("No Coverage Data")).toBe(false);
+    expect(statusBarInfos.includes("Coverage Out of Date")).toBe(false);
   });
 
   it("should run myFirstTest and check its report", async () => {


### PR DESCRIPTION
This PR fixes the issue #210.  The status bar should now display:

1. "Coverage: x/y (z%) - for files that are part of an environment and instrumented 
2. "No Coverage Data" - for files that are part of an environment and NOT instrumented 
3. "Coverage Out of Date" - for files that have been edited since they were last instrumented
4. \<nothing\>: for all other files, including C/C++ files.

Cases 2 and 4 are the "changes"