### PR TITLE
Forced Immediate Output with flush=True in Server Mode Logs

### DIFF
--- a/python/vcastDataServer.py
+++ b/python/vcastDataServer.py
@@ -45,9 +45,9 @@ def init_application(logFilePath):
         # Note: this string must match what is in vcastAdapter.ts -> startServer()
         # We prefix the string with " * " so that it matches the flask output
         print(
-            f" * vcastDataServer is starting on {vcastDataServerTypes.HOST}:{vcastDataServerTypes.PORT}"
+            f" * vcastDataServer is starting on {vcastDataServerTypes.HOST}:{vcastDataServerTypes.PORT}", flush=True
         )
-        print(f" * Server log file path: {logFilePath}")
+        print(f" * Server log file path: {logFilePath}", flush=True)
         logMessage(
             f"{logPrefix()} port: {vcastDataServerTypes.PORT} clicast: {pythonUtilities.globalClicastCommand}\n"
         )


### PR DESCRIPTION
## Summary

In some instances (e.g., when running under Docker) certain Python prints get buffered/not flushed. This causes issues during server startup (e.g., in CI), as important logs were missing, preventing correct server initialization. 

https://github.com/vectorgrp/vector-vscode-vcast/blob/ddb2fa78b31453edb93ffb767354460ce7dc6bbb/src/vcastDataServer.ts#L153

To resolve this, `flush=True` was added to the relevant `print()` statements, ensuring that the output is immediately flushed to the console, allowing the server to start correctly.
