### PR TITLE
Got rid of the generation of the text version of the execution report

### DIFF
--- a/python/clicastInterface.py
+++ b/python/clicastInterface.py
@@ -354,17 +354,11 @@ def generateExecutionReport(enviroPath, testIDObject):
     # We build a clicast command script to generate the execution report
     # since we need multiple commands
     with open(commandFileName, "w") as commandFile:
-        commandFile.write(
-            standardArgs
-            + " report custom actual "
-            + testIDObject.reportName
-            + ".html\n"
-        )
-        commandFile.write("option VCAST_CUSTOM_REPORT_FORMAT TEXT\n")
-        commandFile.write(
-            standardArgs + " report custom actual " + testIDObject.reportName + ".txt\n"
-        )
+        # we force report mode to HTML just to be safe
         commandFile.write("option VCAST_CUSTOM_REPORT_FORMAT HTML\n")
+        commandFile.write(
+            standardArgs + " report custom actual " + testIDObject.reportName
+        )
 
     # we ignore the exit code and return the stdout
     exitCode, stdOutput = runClicastScript(enviroPath, commandFileName)

--- a/python/vTestInterface.py
+++ b/python/vTestInterface.py
@@ -424,7 +424,7 @@ def executeVCtest(enviroPath, testIDObject):
                 returnText += "STATUS:passed\n"
             else:
                 returnText += "STATUS:failed\n"
-            returnText += f"REPORT:{testIDObject.reportName}.txt\n"
+            returnText += f"REPORT:{testIDObject.reportName}\n"
 
             # Retrieve the expected value x/y and the test time
             # we don't need to catch dataAPI errors here because
@@ -474,7 +474,7 @@ def getResults(enviroPath, testIDObject):
             enviroPath, testIDObject
         )
 
-        returnText = f"REPORT:{testIDObject.reportName}.txt\n"
+        returnText = f"REPORT:{testIDObject.reportName}\n"
         returnText += commandOutput
         return returnText
 
@@ -516,7 +516,7 @@ class testID:
         # because we use the parameterized name ... so create a hash
         temp = ".".join([self.unitName, self.functionName, self.testName])
         hashString = hashlib.md5(temp.encode("utf-8")).hexdigest()
-        self.reportName = os.path.join(enviroPath, hashString)
+        self.reportName = os.path.join(enviroPath, hashString) + ".html"
 
 
 def validateClicastCommand(command, mode):
@@ -593,7 +593,7 @@ def processCommandLogic(mode, clicast, pathToUse, testString="", options=""):
         try:
             testIDObject = testID(pathToUse, testString)
             # remove any left over report file ...
-            textReportPath = testIDObject.reportName + ".txt"
+            textReportPath = testIDObject.reportName
             if os.path.isfile(textReportPath):
                 os.remove(textReportPath)
         except:

--- a/src/reporting.ts
+++ b/src/reporting.ts
@@ -117,12 +117,12 @@ pre {
   return returnText;
 }
 
+// TBD TODAY - We switch txt to html ...
 let htmlReportPanel: vscode.WebviewPanel | undefined = undefined;
-function viewResultsReportVC(textFilePath: string) {
+function viewResultsReportVC(htmlFilePath: string) {
   // The stock VectorCAST HTML reports look ugly in VS Code so
   // we do a manual edits, and color changes.
-  const htmlFilePath = textFilePath.replace(".txt", ".html");
-  vectorMessage(`HTML report file path is: ${htmlFilePath}`);
+  vectorMessage(`Report file path is: ${htmlFilePath}`);
   let htmlText = cleanHTML(fs.readFileSync(htmlFilePath, "utf-8"));
   // this displays the html report in a webview panel
   if (!htmlReportPanel) {
@@ -147,9 +147,13 @@ function viewResultsReportVC(textFilePath: string) {
 
 export async function viewResultsReport(testID: string) {
   // make sure that a test is selected
-  const textFilePath = await getResultFileForTest(testID);
-  vectorMessage("Viewing results, result report path: '" + textFilePath + "'");
-  if (fs.existsSync(textFilePath)) {
-    viewResultsReportVC(textFilePath);
+  const htmlFilePath = await getResultFileForTest(testID);
+  if (fs.existsSync(htmlFilePath)) {
+    vectorMessage(
+      "Viewing results, result report path: '" + htmlFilePath + "'"
+    );
+    viewResultsReportVC(htmlFilePath);
+  } else {
+    vectorMessage("Result report file does not exist: '" + htmlFilePath + "'");
   }
 }


### PR DESCRIPTION
Simplifies the code, and prepares for a new execution report generation method based on dataAPI

In the early days we were parsing the summary line in the text report "Expected Results matched 100% ( 1 / 1 )   PASS", but 
- We no longer do this 
- We would use the dataAPI if this is needed in the future.