### PR TITLE
GHA dynamic VectorCAST mounting

### DIFF
--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        vcast: [ 2023sp0, 2024sp4, 2024sp5 ]
+        vcast: [ 2021sp0, 2023sp0, 2024sp4, 2024sp5 ]
 
     steps:
       - name: Check out repository
@@ -209,6 +209,9 @@ jobs:
       GITHUB_SHA: ${{ github.sha }}
       RUN_BY_GROUP: "True"
       RUN_GROUP_NAME: ${{ matrix.group }}
+      ENABLE_ATG_FEATURE: TRUE
+      LM_LICENSE_FILE: /vcast/vector-license.lic
+      VECTOR_LICENSE_FILE: /vcast/vector-license.lic
 
     steps:
       - name: Check out repository

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        vcast: [ 2021sp0, 2023sp0, 2024sp4, 2024sp5 ]
+        vcast: [ 2023sp0, 2024sp4, 2024sp5 ]
 
     steps:
       - name: Check out repository

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -22,7 +22,7 @@ jobs:
 
     container:
       image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:node_18_dynamic_mounting
-      options: --user vcast_user --mount type=bind,source=/home/github/vscode_runners/releases,target=/vcast
+      options: --user vcast_user --mount type=bind,source=${{ vars.VCAST_RELEASES_PATH }},target=/vcast
 
     strategy:
       matrix:
@@ -199,7 +199,7 @@ jobs:
 
     container:
       image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:node_18_dynamic_mounting
-      options: --user vcast_user --mount type=bind,source=/home/github/vscode_runners/releases,target=/vcast
+      options: --user vcast_user --mount type=bind,source=${{ vars.VCAST_RELEASES_PATH }},target=/vcast
 
     strategy:
       matrix:

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -10,8 +10,6 @@ on:
       - main
   release:
   workflow_dispatch:
-#env:
-#  VCAST_VERSIONS: '["2021sp0", "2023sp0", "2024sp4", "2024sp5"]'
 jobs:
   unit-tests:
     if: github.event.pull_request.draft == false
@@ -186,6 +184,8 @@ jobs:
 
       - name: Set jobs matrix
         id: set-matrix
+        env:
+          VCAST_VERSIONS: ${{ vars.VCAST_VERSIONS }}
         run: |
           cd tests/internal/e2e/test
           npx tsx get_gha_matrix.ts

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -78,8 +78,8 @@ jobs:
             exit 1
           fi
           echo 'Activating Vcast ${{ matrix.vcast }}'
-          export VECTORCAST_DIR=$RELEASE_DIR
-          export PATH=$RELEASE_DIR:$PATH
+          echo "VECTORCAST_DIR=$RELEASE_DIR" >> $GITHUB_ENV
+          echo "PATH=$RELEASE_DIR:$PATH" >> $GITHUB_ENV
         shell: bash
 
       - name: Run unit tests
@@ -275,8 +275,8 @@ jobs:
             exit 1
           fi
           echo 'Activating Vcast ${{ matrix.version }}'
-          export VECTORCAST_DIR=$RELEASE_DIR
-          export PATH=$RELEASE_DIR:$PATH
+          echo "VECTORCAST_DIR=$RELEASE_DIR" >> $GITHUB_ENV
+          echo "PATH=$RELEASE_DIR:$PATH" >> $GITHUB_ENV
         shell: bash
 
       - name: Run tests

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -15,14 +15,18 @@ jobs:
     if: github.event.pull_request.draft == false
     permissions: write-all
     runs-on: [self-hosted, vscode-vcast]
+    env:
+      ENABLE_ATG_FEATURE: TRUE
+      LM_LICENSE_FILE: /vcast/vector-license.lic
+      VECTOR_LICENSE_FILE: /vcast/vector-license.lic
 
     container:
-      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:node_18
-      options: --user vcast_user
+      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:sz_test
+      options: --user vcast_user --mount type=bind,source=/home/github/vscode_runners/releases,target=/vcast
 
     strategy:
       matrix:
-        vcast: [ 23, 24 ]
+        vcast: [ 2021sp0, 2023sp0, 2024sp4, 2024sp5 ]
 
     steps:
       - name: Check out repository
@@ -66,15 +70,20 @@ jobs:
       - name: Package with VSCE
         run: npm run package
 
-      - name: Run unit tests
+      - name: Vcast activation
         run: |
-          if [[ ${{ matrix.vcast }} == '24' ]]; then
-            echo 'Activating Vcast 24'
-            export VECTORCAST_DIR=/vcast/release24
-            export PATH=/vcast/release24:$PATH
-            export ENABLE_ATG_FEATURE=TRUE
+          RELEASE_DIR=/vcast/${{ matrix.vcast }}
+          if [ ! -d "$RELEASE_DIR" ]; then
+            echo "Error: $RELEASE_DIR does not exist."
+            exit 1
           fi
-          npm run gh-test | tee output.txt
+          echo 'Activating Vcast ${{ matrix.vcast }}'
+          export VECTORCAST_DIR=$RELEASE_DIR
+          export PATH=$RELEASE_DIR:$PATH
+        shell: bash
+
+      - name: Run unit tests
+        run: npm run gh-test | tee output.txt
         shell: bash
 
       - name: Publish Unit Test Results
@@ -88,7 +97,7 @@ jobs:
             ./test-output.xml
 
       - name: Show coverage summary
-        if: ${{ always() && matrix.vcast == '24' }}
+        if: ${{ always() && strategy.job-index == '0' }}
         run: |
           echo "### Coverage summary - Unit tests" >> $GITHUB_STEP_SUMMARY
           {
@@ -98,7 +107,7 @@ jobs:
           } >> $GITHUB_STEP_SUMMARY
 
       - name: Upload coverage artifacts
-        if: ${{ always() && matrix.vcast == '24' }}
+        if: ${{ always() && strategy.job-index == '0' }}
         run: |
           curl -Os https://uploader.codecov.io/v0.7.1/linux/codecov
           chmod +x codecov
@@ -116,21 +125,21 @@ jobs:
 
       - name: Upload vectorcasttestexplorer artifact
         uses: actions/upload-artifact@v4
-        if: ${{ always() && matrix.vcast == '24' }}
+        if: ${{ always() && strategy.job-index == '0' }}
         with:
           name: vectorcasttestexplorer
           path: ${{ env.VSIX_FILE }}
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
-        if: ${{ always() && matrix.vcast == '24' }}
+        if: ${{ always() && strategy.job-index == '0' }}
         with:
           name: coverage
           path: ./coverage
 
       # Upload release asset
       - name: Upload release asset
-        if: ${{ github.event_name == 'release' && matrix.vcast == '24' }}
+        if: ${{ github.event_name == 'release' && strategy.job-index == '0' }}
         run: |
           url="${{ github.event.release.upload_url }}" && \
           export upload_url=${url%%\{*}?name=vectorcasttestexplorer-${{ github.event.release.tag_name }}.vsix && \
@@ -149,7 +158,7 @@ jobs:
     runs-on: [self-hosted, vscode-vcast]
 
     container:
-      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:node_18
+      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:sz_test
       options: --user vcast_user
 
     outputs:
@@ -187,8 +196,8 @@ jobs:
     runs-on: [self-hosted, vscode-vcast]
 
     container:
-      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:node_18
-      options: --user vcast_user
+      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:sz_test
+      options: --user vcast_user --mount type=bind,source=/home/github/vscode_runners/releases,target=/vcast
 
     strategy:
       matrix:
@@ -198,7 +207,6 @@ jobs:
       BRANCH_REF: ${{ github.ref }}
       GITHUB_REPOSITORY: ${{ github.repository }}
       GITHUB_SHA: ${{ github.sha }}
-      USE_VCAST_24: ${{ matrix.version == 24 && 'True' || 'False' }}
       RUN_BY_GROUP: "True"
       RUN_GROUP_NAME: ${{ matrix.group }}
 
@@ -259,6 +267,18 @@ jobs:
             tests/internal/e2e/.wdio-vscode-service
           key: ${{ runner.os }}-dependencies-webdriver-vscode
 
+      - name: Vcast activation
+        run: |
+          RELEASE_DIR=/vcast/${{ matrix.version }}
+          if [ ! -d "$RELEASE_DIR" ]; then
+            echo "Error: $RELEASE_DIR does not exist."
+            exit 1
+          fi
+          echo 'Activating Vcast ${{ matrix.version }}'
+          export VECTORCAST_DIR=$RELEASE_DIR
+          export PATH=$RELEASE_DIR:$PATH
+        shell: bash
+
       - name: Run tests
         run: |
           ./tests/internal/e2e/run_e2e_tests.sh
@@ -315,7 +335,7 @@ jobs:
     runs-on: [ self-hosted, vscode-vcast]
 
     container:
-      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:node_18
+      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:sz_test
       options: --user vcast_user
 
     steps:
@@ -366,7 +386,7 @@ jobs:
     runs-on: [ self-hosted, vscode-vcast]
 
     container:
-      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:node_18
+      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:sz_test
       options: --user vcast_user
 
     steps:
@@ -418,7 +438,7 @@ jobs:
     runs-on: [ self-hosted, vscode-vcast]
 
     container:
-      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:node_18
+      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:sz_test
       options: --user vcast_user
 
     steps:

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -10,6 +10,8 @@ on:
       - main
   release:
   workflow_dispatch:
+env:
+  VCAST_VERSIONS: '["2021sp0", "2023sp0", "2024sp4", "2024sp5"]'
 jobs:
   unit-tests:
     if: github.event.pull_request.draft == false
@@ -26,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        vcast: [ 2021sp0, 2023sp0, 2024sp4, 2024sp5 ]
+        vcast: ${{ fromJSON(env.VCAST_VERSIONS) }}
 
     steps:
       - name: Check out repository

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -10,8 +10,8 @@ on:
       - main
   release:
   workflow_dispatch:
-env:
-  VCAST_VERSIONS: '["2021sp0", "2023sp0", "2024sp4", "2024sp5"]'
+#env:
+#  VCAST_VERSIONS: '["2021sp0", "2023sp0", "2024sp4", "2024sp5"]'
 jobs:
   unit-tests:
     if: github.event.pull_request.draft == false
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        vcast: ${{ fromJSON(env.VCAST_VERSIONS) }}
+        vcast: ${{ fromJSON(vars.VCAST_VERSIONS) }}
 
     steps:
       - name: Check out repository

--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -21,7 +21,7 @@ jobs:
       VECTOR_LICENSE_FILE: /vcast/vector-license.lic
 
     container:
-      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:sz_test
+      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:node_18_dynamic_mounting
       options: --user vcast_user --mount type=bind,source=/home/github/vscode_runners/releases,target=/vcast
 
     strategy:
@@ -158,7 +158,7 @@ jobs:
     runs-on: [self-hosted, vscode-vcast]
 
     container:
-      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:sz_test
+      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:node_18_dynamic_mounting
       options: --user vcast_user
 
     outputs:
@@ -198,7 +198,7 @@ jobs:
     runs-on: [self-hosted, vscode-vcast]
 
     container:
-      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:sz_test
+      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:node_18_dynamic_mounting
       options: --user vcast_user --mount type=bind,source=/home/github/vscode_runners/releases,target=/vcast
 
     strategy:
@@ -340,7 +340,7 @@ jobs:
     runs-on: [ self-hosted, vscode-vcast]
 
     container:
-      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:sz_test
+      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:node_18_dynamic_mounting
       options: --user vcast_user
 
     steps:
@@ -391,7 +391,7 @@ jobs:
     runs-on: [ self-hosted, vscode-vcast]
 
     container:
-      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:sz_test
+      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:node_18_dynamic_mounting
       options: --user vcast_user
 
     steps:
@@ -443,7 +443,7 @@ jobs:
     runs-on: [ self-hosted, vscode-vcast]
 
     container:
-      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:sz_test
+      image: rds-vtc-docker-dev-local.vegistry.vg.vector.int/vcast/vscode_ubuntu24_ci:node_18_dynamic_mounting
       options: --user vcast_user
 
     steps:

--- a/docker/Ubuntu24-Dockerfile-CI
+++ b/docker/Ubuntu24-Dockerfile-CI
@@ -73,20 +73,7 @@ ENV TESTING_IN_CONTAINER=True \
     RUNNING_ON_SERVER=False \
     PIP_CONFIG_FILE=/home/${USERNAME}/.pip/pip.conf
 
-ADD https://rds-vtc-docker-dev-local.vegistry.vg.vector.int:443/artifactory/rds-build-packages-generic-dev/vcast_test_explorer/vcast.linux64.2023.tar.gz /vcast/releaseVectorCAST23.tar.gz
-ADD http://vabosautofs1.vi.vector.int/JobData/VectorCAST/vc24/deliver/linux64/release.tar.gz /vcast/releaseVectorCAST24.tar.gz
-ADD https://rds-vtc-docker-dev-local.vegistry.vg.vector.int:443/artifactory/rds-build-packages-generic-dev-local/vcast_test_explorer/vector-DEMO-2025.lic /vcast/vector-license.lic
-
-RUN sudo chown -R $(id -u $USERNAME):$(id -g $USERNAME) /vcast
-
-RUN cd /vcast && \
-    tar -xvzf releaseVectorCAST23.tar.gz && rm releaseVectorCAST23.tar.gz && mv vcast release23 && \
-    tar -xvzf releaseVectorCAST24.tar.gz && rm releaseVectorCAST24.tar.gz && mv release release24
-
-ENV VECTORCAST_DIR=/vcast/release23 \
-    PATH=/vcast/release23:$PATH \
-    LM_LICENSE_FILE=/vcast/vector-license.lic \
-    VECTOR_LICENSE_FILE=/vcast/vector-license.lic
+RUN sudo mkdir /vcast && sudo chown -R $(id -u $USERNAME):$(id -g $USERNAME) /vcast
 
 RUN sudo mkdir -m 1777 /__w && sudo chown -R $(id -u $USERNAME):$(id -g $USERNAME) /__w
 

--- a/tests/internal/e2e/run_e2e_tests.sh
+++ b/tests/internal/e2e/run_e2e_tests.sh
@@ -21,13 +21,6 @@ npx tsc "$SPEC_PATH"
 JS_FILE="./test/specs_env_exporter.js"
 SPECS_CONFIG_FILE="./test/specs_config.js"
 
-activate_24_release () {
-  export VECTORCAST_DIR=/vcast/release24
-  export PATH=/vcast/release24:$PATH
-  export ENABLE_ATG_FEATURE=TRUE
-  echo "Vcast 24 is activated"
-}
-
 set_specs_params() {
   # Check if RUN_GROUP_NAME is set
   if [ -z "$RUN_GROUP_NAME" ]; then
@@ -69,10 +62,6 @@ set_specs_params() {
 cd $ROOT
 if [ ! -d "node_modules" ]; then
   npm install
-fi
-
-if [ "$USE_VCAST_24" = "True" ] ; then
-  activate_24_release
 fi
 
 if [ "$GITHUB_ACTIONS" = "true" ] ; then

--- a/tests/internal/e2e/test/get_gha_matrix.ts
+++ b/tests/internal/e2e/test/get_gha_matrix.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import { getSpecGroups } from "./specs_config";
 
 function dumpGhaMatrix() {
-  const versions = ['2021sp0', '2023sp0', '2024sp4', '2024sp5'];
+  const versions = ['2023sp0', '2024sp4', '2024sp5'];
   const result: { version: number; group: string }[] = [];
 
   versions.forEach((version) => {

--- a/tests/internal/e2e/test/get_gha_matrix.ts
+++ b/tests/internal/e2e/test/get_gha_matrix.ts
@@ -3,6 +3,13 @@ import { getSpecGroups } from "./specs_config";
 
 function dumpGhaMatrix() {
   const versions = ["2021sp0", "2023sp0", "2024sp4", "2024sp5"];
+
+  const versionsJson = process.env.VCAST_VERSIONS;
+  if (!versionsJson) {
+    throw new Error("VERSIONS_JSON environment variable is not set.");
+  }
+
+  const versions = JSON.parse(versionsJson);
   const result: { version: number; group: string }[] = [];
 
   versions.forEach((version) => {

--- a/tests/internal/e2e/test/get_gha_matrix.ts
+++ b/tests/internal/e2e/test/get_gha_matrix.ts
@@ -2,11 +2,11 @@ import * as fs from "fs";
 import { getSpecGroups } from "./specs_config";
 
 function dumpGhaMatrix() {
-  const versions = [23, 24];
+  const versions = ['2021sp0', '2023sp0', '2024sp4', '2024sp5'];
   const result: { version: number; group: string }[] = [];
 
   versions.forEach((version) => {
-    const vcast24 = version === 24;
+    const vcast24 = version.startsWith('2024');
     const specs = getSpecGroups(vcast24);
     Object.keys(specs).forEach((group) => {
       result.push({ version, group });

--- a/tests/internal/e2e/test/get_gha_matrix.ts
+++ b/tests/internal/e2e/test/get_gha_matrix.ts
@@ -2,8 +2,6 @@ import * as fs from "fs";
 import { getSpecGroups } from "./specs_config";
 
 function dumpGhaMatrix() {
-  const versions = ["2021sp0", "2023sp0", "2024sp4", "2024sp5"];
-
   const versionsJson = process.env.VCAST_VERSIONS;
   if (!versionsJson) {
     throw new Error("VERSIONS_JSON environment variable is not set.");

--- a/tests/internal/e2e/test/get_gha_matrix.ts
+++ b/tests/internal/e2e/test/get_gha_matrix.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import { getSpecGroups } from "./specs_config";
 
 function dumpGhaMatrix() {
-  const versions = ["2023sp0", "2024sp4", "2024sp5"];
+  const versions = ["2021sp0", "2023sp0", "2024sp4", "2024sp5"];
   const result: { version: number; group: string }[] = [];
 
   versions.forEach((version) => {

--- a/tests/internal/e2e/test/get_gha_matrix.ts
+++ b/tests/internal/e2e/test/get_gha_matrix.ts
@@ -4,7 +4,7 @@ import { getSpecGroups } from "./specs_config";
 function dumpGhaMatrix() {
   const versionsJson = process.env.VCAST_VERSIONS;
   if (!versionsJson) {
-    throw new Error("VERSIONS_JSON environment variable is not set.");
+    throw new Error("VCAST_VERSIONS environment variable is not set.");
   }
 
   const versions = JSON.parse(versionsJson);

--- a/tests/internal/e2e/test/get_gha_matrix.ts
+++ b/tests/internal/e2e/test/get_gha_matrix.ts
@@ -2,11 +2,11 @@ import * as fs from "fs";
 import { getSpecGroups } from "./specs_config";
 
 function dumpGhaMatrix() {
-  const versions = ['2023sp0', '2024sp4', '2024sp5'];
+  const versions = ["2023sp0", "2024sp4", "2024sp5"];
   const result: { version: number; group: string }[] = [];
 
   versions.forEach((version) => {
-    const vcast24 = version.startsWith('2024');
+    const vcast24 = version.startsWith("2024");
     const specs = getSpecGroups(vcast24);
     Object.keys(specs).forEach((group) => {
       result.push({ version, group });

--- a/tests/internal/e2e/test/specs/vcast_build_env_failure_different_paths.test.ts
+++ b/tests/internal/e2e/test/specs/vcast_build_env_failure_different_paths.test.ts
@@ -118,7 +118,7 @@ describe("vTypeCheck VS Code Extension", () => {
     const testingView = await activityBar.getViewControl("Testing");
     await testingView?.openView();
 
-    await expectEnvResults("release23");
+    await expectEnvResults("2023sp0");
   });
 
   it("should change to release 24 and confirm the presence of ENV_24_02 and ENV_24_04", async () => {
@@ -134,7 +134,7 @@ describe("vTypeCheck VS Code Extension", () => {
       vcastRoot = path.join(process.env.HOME, "vcast");
     }
 
-    const newVersion = "release24";
+    const newVersion = "2024sp4";
     const release24Path = path.join(vcastRoot, newVersion);
 
     const workbench = await browser.getWorkbench();
@@ -162,7 +162,7 @@ describe("vTypeCheck VS Code Extension", () => {
     const testingView = await activityBar.getViewControl("Testing");
     await testingView?.openView();
 
-    await expectEnvResults("release24");
+    await expectEnvResults("2024sp4");
   });
 });
 
@@ -173,7 +173,7 @@ describe("vTypeCheck VS Code Extension", () => {
 async function expectEnvResults(release: string) {
   const envMap = new Map<string, Array<{ env: string; state: string }>>([
     [
-      "release23",
+      "2023sp0",
       [
         { env: "ENV_23_01", state: "defined" },
         { env: "ENV_24_02", state: "undefined" },
@@ -182,7 +182,7 @@ async function expectEnvResults(release: string) {
       ],
     ],
     [
-      "release24",
+      "2024sp4",
       [
         { env: "ENV_23_01", state: "undefined" },
         { env: "ENV_24_02", state: "defined" },

--- a/tests/internal/e2e/test/specs_config.ts
+++ b/tests/internal/e2e/test/specs_config.ts
@@ -146,8 +146,6 @@ export function getSpecsWithEnv(useVcast24: boolean) {
     // In that case we don t want the release to be on PATH
     if (groupObject.params?.vcReleaseOnPath === false) {
       const pathWithoutRelease = removeReleaseOnPath();
-      console.log("PATH WITHOUT RELEASE: ");
-      console.log(pathWithoutRelease);
       if (pathWithoutRelease !== undefined) {
         groupObject.env.PATH = pathWithoutRelease;
       }

--- a/tests/internal/e2e/test/specs_config.ts
+++ b/tests/internal/e2e/test/specs_config.ts
@@ -146,6 +146,8 @@ export function getSpecsWithEnv(useVcast24: boolean) {
     // In that case we don t want the release to be on PATH
     if (groupObject.params?.vcReleaseOnPath === false) {
       const pathWithoutRelease = removeReleaseOnPath();
+      console.log("PATH WITHOUT RELEASE: ");
+      console.log(pathWithoutRelease);
       if (pathWithoutRelease !== undefined) {
         groupObject.env.PATH = pathWithoutRelease;
       }
@@ -210,7 +212,7 @@ export function getSpecs(vcast24: boolean, group: string = null) {
 }
 
 /**
- * Splits all paths from the PATH env variable that contain a year followed by "sp" and a number (e.g., 2023sp2).
+ * Splits all paths from the PATH env variable that contain a year followed by "sp" and a number (e.g., 2023sp0).
  * @returns New PATH env var without those paths
  */
 function removeReleaseOnPath(): string | undefined {
@@ -225,8 +227,8 @@ function removeReleaseOnPath(): string | undefined {
   // Split the PATH on ":"
   const paths = envPath.split(":");
 
-  // Regex to match paths that start with a year followed by "sp" and a number (e.g., 2023sp0)
-  const releaseRegex = /^\d{4}sp\d+/;
+  // Regex to match paths containing "vcast/" followed by a four-digit year and "sp" with a number (e.g., /vcast/2023sp0)
+  const releaseRegex = /\/vcast\/\d{4}sp\d+/;
 
   // Filter out paths that match the new release pattern
   const filteredPaths = paths.filter((path) => !releaseRegex.test(path));

--- a/tests/internal/e2e/test/specs_config.ts
+++ b/tests/internal/e2e/test/specs_config.ts
@@ -38,7 +38,7 @@ export function getSpecGroups(useVcast24: boolean) {
     build_different_envs: {
       specs: ["./**/**/vcast_build_env_failure_different_paths.test.ts"],
       env: {
-        VECTORCAST_DIR: `/vcast/release23:${process.env.HOME}/vcast/release23`,
+        VECTORCAST_DIR: `/vcast/2023sp0:${process.env.HOME}/vcast/2023sp0`,
         BUILD_MULTIPLE_ENVS: "True",
       },
       params: {},

--- a/tests/internal/e2e/test/specs_config.ts
+++ b/tests/internal/e2e/test/specs_config.ts
@@ -210,8 +210,8 @@ export function getSpecs(vcast24: boolean, group: string = null) {
 }
 
 /**
- * Splits all paths from the PATH env variable that contain a "release".
- * @returns New PATH env var without "release" paths
+ * Splits all paths from the PATH env variable that contain a year followed by "sp" and a number (e.g., 2023sp2).
+ * @returns New PATH env var without those paths
  */
 function removeReleaseOnPath(): string | undefined {
   // Get the PATH environment variable
@@ -225,8 +225,11 @@ function removeReleaseOnPath(): string | undefined {
   // Split the PATH on ":"
   const paths = envPath.split(":");
 
-  // Filter out paths that contain "release"
-  const filteredPaths = paths.filter((path) => !path.includes("release"));
+  // Regex to match paths that start with a year followed by "sp" and a number (e.g., 2023sp0)
+  const releaseRegex = /^\d{4}sp\d+/;
+
+  // Filter out paths that match the new release pattern
+  const filteredPaths = paths.filter((path) => !releaseRegex.test(path));
 
   // Join the remaining paths back together with ":"
   const newPath = filteredPaths.join(":");

--- a/tests/internal/e2e/test/wdio.conf.ts
+++ b/tests/internal/e2e/test/wdio.conf.ts
@@ -444,7 +444,7 @@ export const config: Options.Testrunner = {
       );
 
       const vcastRoot = await getVcastRoot();
-      const newVersion = "release24";
+      const newVersion = "2024sp4";
 
       // Set up environment directory
       process.env.VECTORCAST_DIR = path.join(vcastRoot, newVersion);
@@ -537,8 +537,8 @@ TEST.END`;
     async function setupMultipleEnvironments() {
       const vcastRoot = await getVcastRoot();
 
-      const oldVersion = "release23";
-      const newVersion = "release24";
+      const oldVersion = "2023sp0";
+      const newVersion = "2024sp4";
 
       // Total amount of envs to be build
       const totalEnvCount = 4;

--- a/tests/internal/e2e/test/wdio.conf.ts
+++ b/tests/internal/e2e/test/wdio.conf.ts
@@ -412,8 +412,6 @@ export const config: Options.Testrunner = {
           "vpython"
         );
         process.env.PATH = `${newPath}${path.delimiter}${currentPath}`;
-        console.log("PATH IN WDIO");
-        console.log(process.env.PATH);
         clicastExecutablePath = `${process.env.VECTORCAST_DIR_TEST_DUPLICATE}/clicast`;
         process.env.CLICAST_PATH = clicastExecutablePath;
 

--- a/tests/internal/e2e/test/wdio.conf.ts
+++ b/tests/internal/e2e/test/wdio.conf.ts
@@ -412,6 +412,8 @@ export const config: Options.Testrunner = {
           "vpython"
         );
         process.env.PATH = `${newPath}${path.delimiter}${currentPath}`;
+        console.log("PATH IN WDIO");
+        console.log(process.env.PATH);
         clicastExecutablePath = `${process.env.VECTORCAST_DIR_TEST_DUPLICATE}/clicast`;
         process.env.CLICAST_PATH = clicastExecutablePath;
 


### PR DESCRIPTION
Adding dynamic mounting of the VectorCAST releases to the Docker container used for the CI. This way there is no need to rebuild the image when adding, updating or deleting a release to be used in Actions. 
The versions list is controlled via the actions variable `VCAST_VERSIONS`, and the path where the releases are stored on the host machine is given via the actions variable `VCAST_RELEASES_PATH`