### PR TITLE
Clicast server release test fix after CI changes

### DIFF
--- a/.github/workflows/run-tests-workflow.yml
+++ b/.github/workflows/run-tests-workflow.yml
@@ -82,6 +82,10 @@ jobs:
           echo "PATH=$RELEASE_DIR:$PATH" >> $GITHUB_ENV
         shell: bash
 
+      - name: Clicast server tests
+        run: ./tests/clicast-server/run_clicast_server_tests.sh
+        shell: bash
+
       - name: Run unit tests
         run: npm run gh-test | tee output.txt
         shell: bash
@@ -282,6 +286,8 @@ jobs:
           echo 'Activating Vcast ${{ matrix.version }}'
           echo "VECTORCAST_DIR=$RELEASE_DIR" >> $GITHUB_ENV
           echo "PATH=$RELEASE_DIR:$PATH" >> $GITHUB_ENV
+          USE_VCAST_24=$(if [[ $(cat $RELEASE_DIR/DATA/tool_version.txt) == 24* ]]; then echo "True"; else echo "False"; fi)
+          echo "USE_VCAST_24=$USE_VCAST_24" >> $GITHUB_ENV
         shell: bash
 
       - name: Run tests

--- a/tests/clicast-server/run_clicast_server_tests.sh
+++ b/tests/clicast-server/run_clicast_server_tests.sh
@@ -15,7 +15,26 @@ export PYTHONPATH=$(realpath $ROOT/../../python)
 $VECTORCAST_DIR/vpython $ROOT/../../python/vcastDataServer.py &
 SERVER_PID=$!
 
-SERVER_PORT=60461
+echo "Waiting for the Flask server to start..."
+max_retries=10
+retry_count=0
+while true; do
+    if [[ $retry_count -ge $max_retries ]]; then
+        echo "Failed to get server port."
+        kill $SERVER_PID
+        exit 1
+    fi
+    if [[ -f "vcastDataServer.log" ]]; then
+        SERVER_PORT=$(grep "vcastDataServer" vcastDataServer.log | sed -n 's/.*port: \([0-9]*\).*/\1/p')
+        if [[ -n "$SERVER_PORT" ]]; then
+            echo "Port number found: $SERVER_PORT"
+            break
+        fi
+    fi
+    retry_count=$((retry_count+1))
+    sleep 1
+done
+
 
 health_check_url="http://127.0.0.1:$SERVER_PORT"
 max_retries=10

--- a/tests/clicast-server/run_clicast_server_tests.sh
+++ b/tests/clicast-server/run_clicast_server_tests.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+ROOT=$(dirname "$(realpath "$0")")
+
+VCAST_24_REFERENCE_DATE=$(date -d "04/03/24" +%Y%m%d)  # This is the release date for vcast 2024sp1
+
+THIS_RELEASE_DATE_STR=$(grep -oP '\(\K[^)]+' "$VECTORCAST_DIR/DATA/tool_version.txt")
+THIS_RELEASE_DATE=$(date -d "$THIS_RELEASE_DATE_STR" +%Y%m%d)
+
+if [[ $THIS_RELEASE_DATE -lt $VCAST_24_REFERENCE_DATE ]]; then
+    echo "This VectorCAST release does not support clicast server."
+    exit 0
+fi
+
+export PYTHONPATH=$(realpath $ROOT/../../python)
+$VECTORCAST_DIR/vpython $ROOT/../../python/vcastDataServer.py &
+SERVER_PID=$!
+
+SERVER_PORT=60461
+
+health_check_url="http://127.0.0.1:$SERVER_PORT"
+max_retries=10
+retry_count=0
+echo "Waiting for the Flask server to start..."
+while ! curl -s $health_check_url > /dev/null; do
+    if [[ $retry_count -ge $max_retries ]]; then
+        echo "Flask server failed to start."
+        kill $SERVER_PID
+        exit 1
+    fi
+    retry_count=$((retry_count+1))
+    sleep 1
+done
+
+$VECTORCAST_DIR/vpython $ROOT/client.py --port=$SERVER_PORT --test=full
+
+kill $SERVER_PID

--- a/tests/internal/e2e/test/specs/vcast.build_env.test.ts
+++ b/tests/internal/e2e/test/specs/vcast.build_env.test.ts
@@ -9,20 +9,22 @@ import {
   checkIfRequestInLogs,
 } from "../test_utils/vcast_utils";
 import { TIMEOUT } from "../test_utils/vcast_utils";
+import { checkForServerRunnability } from "../../../../unit/getToolversion";
 
 describe("vTypeCheck VS Code Extension", () => {
   let bottomBar: BottomBarPanel;
   let workbench: Workbench;
   let useDataServer: boolean = true;
-  if (process.env.VCAST_USE_PYTHON) {
-    useDataServer = false;
-  }
   before(async () => {
     workbench = await browser.getWorkbench();
     // Opening bottom bar and problems view before running any tests
     bottomBar = workbench.getBottomBar();
     await bottomBar.toggle(true);
     process.env.E2E_TEST_ID = "0";
+    let releaseIsSuitableForServer = await checkForServerRunnability();
+    if (process.env.VCAST_USE_PYTHON || !releaseIsSuitableForServer) {
+      useDataServer = false;
+    }
   });
 
   it("test 1: should be able to load VS Code", async () => {

--- a/tests/internal/e2e/test/specs/vcast.create_script_1.test.ts
+++ b/tests/internal/e2e/test/specs/vcast.create_script_1.test.ts
@@ -15,20 +15,22 @@ import {
   checkIfRequestInLogs,
 } from "../test_utils/vcast_utils";
 import { TIMEOUT } from "../test_utils/vcast_utils";
+import { checkForServerRunnability } from "../../../../unit/getToolversion";
 
 describe("vTypeCheck VS Code Extension", () => {
   let bottomBar: BottomBarPanel;
   let workbench: Workbench;
   let useDataServer: boolean = true;
-  if (process.env.VCAST_USE_PYTHON) {
-    useDataServer = false;
-  }
   before(async () => {
     workbench = await browser.getWorkbench();
     // Opening bottom bar and problems view before running any tests
     bottomBar = workbench.getBottomBar();
     await bottomBar.toggle(true);
     process.env.E2E_TEST_ID = "0";
+    let releaseIsSuitableForServer = await checkForServerRunnability();
+    if (process.env.VCAST_USE_PYTHON || !releaseIsSuitableForServer) {
+      useDataServer = false;
+    }
   });
 
   it("test 1: should be able to load VS Code", async () => {

--- a/tests/internal/e2e/test/specs/vcast.create_script_2_and_run.test.ts
+++ b/tests/internal/e2e/test/specs/vcast.create_script_2_and_run.test.ts
@@ -19,6 +19,7 @@ import {
   toggleDataServer,
 } from "../test_utils/vcast_utils";
 import { TIMEOUT } from "../test_utils/vcast_utils";
+import { checkForServerRunnability } from "../../../../unit/getToolversion";
 
 describe("vTypeCheck VS Code Extension", () => {
   let bottomBar: BottomBarPanel;
@@ -26,9 +27,7 @@ describe("vTypeCheck VS Code Extension", () => {
   let editorView: EditorView;
   let statusBar: StatusBar;
   let useDataServer: boolean = true;
-  if (process.env.VCAST_USE_PYTHON) {
-    useDataServer = false;
-  }
+
   before(async () => {
     workbench = await browser.getWorkbench();
     // Opening bottom bar and problems view before running any tests
@@ -36,6 +35,10 @@ describe("vTypeCheck VS Code Extension", () => {
     await bottomBar.toggle(true);
     editorView = workbench.getEditorView();
     process.env.E2E_TEST_ID = "0";
+    let releaseIsSuitableForServer = await checkForServerRunnability();
+    if (process.env.VCAST_USE_PYTHON || !releaseIsSuitableForServer) {
+      useDataServer = false;
+    }
   });
 
   it("test 1: should be able to load VS Code", async () => {

--- a/tests/internal/e2e/test/specs/vcast_server_specifics.test.ts
+++ b/tests/internal/e2e/test/specs/vcast_server_specifics.test.ts
@@ -103,7 +103,7 @@ describe("vTypeCheck VS Code Extension", () => {
   });
 
   it("should set PATH to 2024sp4", async () => {
-    // Need to skip the checksif we are on 2024sp4 from the beginning (on CI) --> server mode is not activated there
+    // Need to skip the checks if we are on 2024sp4 from the beginning (on CI) --> server mode is not activated there
     if (useDataServer) {
       const outputView = await bottomBar.openOutputView();
       // Check if we are on CI

--- a/tests/internal/e2e/test/specs/vcast_server_specifics.test.ts
+++ b/tests/internal/e2e/test/specs/vcast_server_specifics.test.ts
@@ -9,16 +9,22 @@ import {
   getLastLineOfOutputView,
   TIMEOUT,
 } from "../test_utils/vcast_utils";
+import { checkForServerRunnability } from "../../../../unit/getToolversion";
 
 describe("vTypeCheck VS Code Extension", () => {
   let bottomBar: BottomBarPanel;
   let workbench: Workbench;
+  let useDataServer: boolean = true;
   before(async () => {
     workbench = await browser.getWorkbench();
     // Opening bottom bar and problems view before running any tests
     bottomBar = workbench.getBottomBar();
     await bottomBar.toggle(true);
     process.env.E2E_TEST_ID = "0";
+    let releaseIsSuitableForServer = await checkForServerRunnability();
+    if (process.env.VCAST_USE_PYTHON || !releaseIsSuitableForServer) {
+      useDataServer = false;
+    }
   });
 
   it("test 1: should be able to load VS Code", async () => {
@@ -97,162 +103,169 @@ describe("vTypeCheck VS Code Extension", () => {
   });
 
   it("should set PATH to 2024sp4", async () => {
-    const outputView = await bottomBar.openOutputView();
-    // Check if we are on CI
-    let vcastRoot: string;
-    if (process.env.HOME.startsWith("/github")) {
-      vcastRoot = "/vcast";
-    } else {
-      // Assuming that locally release is on this path.
-      vcastRoot = path.join(process.env.HOME, "vcast");
+    // Need to skip the checksif we are on 2024sp4 from the beginning (on CI) --> server mode is not activated there
+    if (useDataServer) {
+      const outputView = await bottomBar.openOutputView();
+      // Check if we are on CI
+      let vcastRoot: string;
+      if (process.env.HOME.startsWith("/github")) {
+        vcastRoot = "/vcast";
+      } else {
+        // Assuming that locally release is on this path.
+        vcastRoot = path.join(process.env.HOME, "vcast");
+      }
+
+      const newVersion = "2024sp4";
+      const release24Path = path.join(vcastRoot, newVersion);
+
+      const workbench = await browser.getWorkbench();
+      const activityBar = workbench.getActivityBar();
+      const explorerView = await activityBar.getViewControl("Explorer");
+      await explorerView?.openView();
+
+      // Put in release 24_sp4 path in settings
+      const settingsEditor = await workbench.openSettings();
+      const unitTestLocationSetting = await settingsEditor.findSetting(
+        "Vectorcast Installation Location",
+        "Vectorcast Test Explorer"
+      );
+
+      await unitTestLocationSetting.setValue(release24Path);
+
+      const notificationsCenter = await workbench.openNotificationsCenter();
+      await notificationsCenter.clearAllNotifications();
+
+      await browser.waitUntil(
+        async () =>
+          (await outputView.getText())
+            .toString()
+            .includes("VectorCAST Data Server exited successfully"),
+        { timeout: TIMEOUT }
+      );
+
+      let statusBar = workbench.getStatusBar();
+      // When setting to a wrong path, vDataServer Status Button should be disabled
+      const statusBarInfos = await statusBar.getItems();
+      expect(statusBarInfos.includes("vDataServer On")).toBe(false);
+      expect(statusBarInfos.includes("vDataServer Off")).toBe(false);
     }
-
-    const newVersion = "2024sp4";
-    const release24Path = path.join(vcastRoot, newVersion);
-
-    const workbench = await browser.getWorkbench();
-    const activityBar = workbench.getActivityBar();
-    const explorerView = await activityBar.getViewControl("Explorer");
-    await explorerView?.openView();
-
-    // Put in release 24_sp4 path in settings
-    const settingsEditor = await workbench.openSettings();
-    const unitTestLocationSetting = await settingsEditor.findSetting(
-      "Vectorcast Installation Location",
-      "Vectorcast Test Explorer"
-    );
-
-    await unitTestLocationSetting.setValue(release24Path);
-
-    const notificationsCenter = await workbench.openNotificationsCenter();
-    await notificationsCenter.clearAllNotifications();
-
-    await browser.waitUntil(
-      async () =>
-        (await outputView.getText())
-          .toString()
-          .includes("VectorCAST Data Server exited successfully"),
-      { timeout: TIMEOUT }
-    );
-
-    let statusBar = workbench.getStatusBar();
-    // When setting to a wrong path, vDataServer Status Button should be disabled
-    const statusBarInfos = await statusBar.getItems();
-    expect(statusBarInfos.includes("vDataServer On")).toBe(false);
-    expect(statusBarInfos.includes("vDataServer Off")).toBe(false);
   });
 
   it("should toggle `Use Data Server` off & on", async () => {
-    await updateTestID();
-    const workbench = await browser.getWorkbench();
-    const settingsEditor = await workbench.openSettings();
+    if (useDataServer) {
+      await updateTestID();
+      const workbench = await browser.getWorkbench();
+      const settingsEditor = await workbench.openSettings();
 
-    console.log("Looking for Use Data Server settings");
-    await settingsEditor.findSetting("vectorcastTestExplorer.useDataServer");
+      console.log("Looking for Use Data Server settings");
+      await settingsEditor.findSetting("vectorcastTestExplorer.useDataServer");
 
-    // Get the initial last line of the output view
-    let lastLineBefore = await getLastLineOfOutputView(bottomBar);
+      // Get the initial last line of the output view
+      let lastLineBefore = await getLastLineOfOutputView(bottomBar);
 
-    // Toggle `Use Data Server` OFF
-    console.log("Turning on `Use Data Server` in Settings");
-    await (await settingsEditor.checkboxSetting$).click();
+      // Toggle `Use Data Server` OFF
+      console.log("Turning on `Use Data Server` in Settings");
+      await (await settingsEditor.checkboxSetting$).click();
 
-    // Wait for 2 seconds to be sure no new messages come as we expect nothing to come
-    await browser.pause(2000);
+      // Wait for 2 seconds to be sure no new messages come as we expect nothing to come
+      await browser.pause(2000);
 
-    // Get the new last line after toggling
-    let lastLineAfter = await getLastLineOfOutputView(bottomBar);
-    expect(lastLineBefore).toEqual(lastLineAfter);
+      // Get the new last line after toggling
+      let lastLineAfter = await getLastLineOfOutputView(bottomBar);
+      expect(lastLineBefore).toEqual(lastLineAfter);
 
-    // Toggle `Use Data Server` OFF
-    console.log("Turning off `Use Data Server` in Settings");
-    await (await settingsEditor.checkboxSetting$).click();
+      // Toggle `Use Data Server` OFF
+      console.log("Turning off `Use Data Server` in Settings");
+      await (await settingsEditor.checkboxSetting$).click();
 
-    // Wait for 2 seconds to be sure no new messages come as we expect nothing to come
-    await browser.pause(2000);
+      // Wait for 2 seconds to be sure no new messages come as we expect nothing to come
+      await browser.pause(2000);
 
-    // Get the new last line after toggling
-    lastLineAfter = await getLastLineOfOutputView(bottomBar);
-    expect(lastLineBefore).toEqual(lastLineAfter);
+      // Get the new last line after toggling
+      lastLineAfter = await getLastLineOfOutputView(bottomBar);
+      expect(lastLineBefore).toEqual(lastLineAfter);
 
-    // Toggle `Use Data Server` ON
-    console.log("Turning on `Use Data Server` in Settings");
-    await (await settingsEditor.checkboxSetting$).click();
+      // Toggle `Use Data Server` ON
+      console.log("Turning on `Use Data Server` in Settings");
+      await (await settingsEditor.checkboxSetting$).click();
 
-    // Wait for 2 seconds to be sure no new messages come as we expect nothing to come
-    await browser.pause(2000);
+      // Wait for 2 seconds to be sure no new messages come as we expect nothing to come
+      await browser.pause(2000);
 
-    // Get the new last line after toggling
-    lastLineAfter = await getLastLineOfOutputView(bottomBar);
-    expect(lastLineBefore).toEqual(lastLineAfter);
+      // Get the new last line after toggling
+      lastLineAfter = await getLastLineOfOutputView(bottomBar);
+      expect(lastLineBefore).toEqual(lastLineAfter);
 
-    // Close all editors at the end of the test
-    await workbench.getEditorView().closeAllEditors();
+      // Close all editors at the end of the test
+      await workbench.getEditorView().closeAllEditors();
+    }
   });
 
   it("should set version to vc24_sp5", async () => {
-    const outputView = await bottomBar.openOutputView();
-    // Check if we are on CI
-    let vcastRoot: string;
-    if (process.env.HOME.startsWith("/github")) {
-      vcastRoot = "/vcast";
-    } else {
-      // Assuming that locally release is on this path.
-      vcastRoot = path.join(process.env.HOME, "vcast");
+    if (useDataServer) {
+      const outputView = await bottomBar.openOutputView();
+      // Check if we are on CI
+      let vcastRoot: string;
+      if (process.env.HOME.startsWith("/github")) {
+        vcastRoot = "/vcast";
+      } else {
+        // Assuming that locally release is on this path.
+        vcastRoot = path.join(process.env.HOME, "vcast");
+      }
+
+      const newVersion = "2024sp5";
+      const release24Path = path.join(vcastRoot, newVersion);
+
+      const workbench = await browser.getWorkbench();
+      const activityBar = workbench.getActivityBar();
+      const explorerView = await activityBar.getViewControl("Explorer");
+      await explorerView?.openView();
+
+      // Put in release 24_sp5 path in settings
+      const settingsEditor = await workbench.openSettings();
+      const unitTestLocationSetting = await settingsEditor.findSetting(
+        "Vectorcast Installation Location",
+        "Vectorcast Test Explorer"
+      );
+
+      await unitTestLocationSetting.setValue(release24Path);
+
+      const notificationsCenter = await workbench.openNotificationsCenter();
+      await notificationsCenter.clearAllNotifications();
+
+      await browser.waitUntil(
+        async () =>
+          (await outputView.getText())
+            .toString()
+            .includes("Started VectorCAST Data Server"),
+        { timeout: TIMEOUT }
+      );
+
+      let statusBar = workbench.getStatusBar();
+      await browser.waitUntil(
+        async () => (await statusBar.getItems()).includes("vDataServer On"),
+        { timeout: TIMEOUT }
+      );
+
+      // Set path back again to something "junk"
+      await unitTestLocationSetting.setValue("junk");
+
+      //Need to clear, otherwise we won't wait for the message as it is already there from the steps before
+      outputView.clearText();
+      await bottomBar.toggle(true);
+
+      await browser.waitUntil(
+        async () =>
+          (await outputView.getText())
+            .toString()
+            .includes("VectorCAST Data Server exited successfully"),
+        { timeout: TIMEOUT }
+      );
+
+      // When setting to a wrong path, vDataServer Status Button should be disabled
+      const statusBarInfos = await statusBar.getItems();
+      expect(statusBarInfos.includes("vDataServer On")).toBe(false);
+      expect(statusBarInfos.includes("vDataServer Off")).toBe(false);
     }
-
-    const newVersion = "2024sp5";
-    const release24Path = path.join(vcastRoot, newVersion);
-
-    const workbench = await browser.getWorkbench();
-    const activityBar = workbench.getActivityBar();
-    const explorerView = await activityBar.getViewControl("Explorer");
-    await explorerView?.openView();
-
-    // Put in release 24_sp5 path in settings
-    const settingsEditor = await workbench.openSettings();
-    const unitTestLocationSetting = await settingsEditor.findSetting(
-      "Vectorcast Installation Location",
-      "Vectorcast Test Explorer"
-    );
-
-    await unitTestLocationSetting.setValue(release24Path);
-
-    const notificationsCenter = await workbench.openNotificationsCenter();
-    await notificationsCenter.clearAllNotifications();
-
-    await browser.waitUntil(
-      async () =>
-        (await outputView.getText())
-          .toString()
-          .includes("Started VectorCAST Data Server"),
-      { timeout: TIMEOUT }
-    );
-
-    let statusBar = workbench.getStatusBar();
-    await browser.waitUntil(
-      async () => (await statusBar.getItems()).includes("vDataServer On"),
-      { timeout: TIMEOUT }
-    );
-
-    // Set path back again to something "junk"
-    await unitTestLocationSetting.setValue("junk");
-
-    //Need to clear, otherwise we won't wait for the message as it is already there from the steps before
-    outputView.clearText();
-    await bottomBar.toggle(true);
-
-    await browser.waitUntil(
-      async () =>
-        (await outputView.getText())
-          .toString()
-          .includes("VectorCAST Data Server exited successfully"),
-      { timeout: TIMEOUT }
-    );
-
-    // When setting to a wrong path, vDataServer Status Button should be disabled
-    const statusBarInfos = await statusBar.getItems();
-    expect(statusBarInfos.includes("vDataServer On")).toBe(false);
-    expect(statusBarInfos.includes("vDataServer Off")).toBe(false);
   });
 });

--- a/tests/internal/e2e/test/specs/vcast_server_specifics.test.ts
+++ b/tests/internal/e2e/test/specs/vcast_server_specifics.test.ts
@@ -96,7 +96,7 @@ describe("vTypeCheck VS Code Extension", () => {
     await (await $("aria/Set as VectorCAST Configuration File")).click();
   });
 
-  it("should set PATH to release24_sp4", async () => {
+  it("should set PATH to 2024sp4", async () => {
     const outputView = await bottomBar.openOutputView();
     // Check if we are on CI
     let vcastRoot: string;
@@ -107,7 +107,7 @@ describe("vTypeCheck VS Code Extension", () => {
       vcastRoot = path.join(process.env.HOME, "vcast");
     }
 
-    const newVersion = "release24_sp4";
+    const newVersion = "2024sp4";
     const release24Path = path.join(vcastRoot, newVersion);
 
     const workbench = await browser.getWorkbench();
@@ -201,7 +201,7 @@ describe("vTypeCheck VS Code Extension", () => {
       vcastRoot = path.join(process.env.HOME, "vcast");
     }
 
-    const newVersion = "release24_sp5";
+    const newVersion = "2024sp5";
     const release24Path = path.join(vcastRoot, newVersion);
 
     const workbench = await browser.getWorkbench();

--- a/tests/internal/e2e/test/specs_config.ts
+++ b/tests/internal/e2e/test/specs_config.ts
@@ -133,17 +133,17 @@ export function getSpecGroups(useVcast24: boolean) {
       params: {},
     };
 
-    specGroups["coded_mock_different_env"] = {
-      specs: ["./**/**/vcast_coded_test_different_envs_hover.test.ts"],
-      env: {
-        VCAST_USE_PYTHON: "True",
-        VECTORCAST_DIR: `/vcast/2024sp1:${process.env.HOME}/vcast/2024sp1`,
-        SWITCH_ENV_AT_THE_END: "True",
-      },
-      params: {
-        vcReleaseOnPath: false,
-      },
-    };
+    // specGroups["coded_mock_different_env"] = {
+    //   specs: ["./**/**/vcast_coded_test_different_envs_hover.test.ts"],
+    //   env: {
+    //     VCAST_USE_PYTHON: "True",
+    //     VECTORCAST_DIR: `/vcast/2024sp1:${process.env.HOME}/vcast/2024sp1`,
+    //     SWITCH_ENV_AT_THE_END: "True",
+    //   },
+    //   params: {
+    //     vcReleaseOnPath: false,
+    //   },
+    // };
 
     specGroups["basic_user_interactions_server"] = {
       specs: [
@@ -260,16 +260,16 @@ export function getSpecGroups(useVcast24: boolean) {
       params: {},
     };
 
-    specGroups["coded_mock_different_env_server"] = {
-      specs: ["./**/**/vcast_coded_test_different_envs_hover.test.ts"],
-      env: {
-        VECTORCAST_DIR: `/vcast/2024sp1:${process.env.HOME}/vcast/2024sp1`,
-        SWITCH_ENV_AT_THE_END: "True",
-      },
-      params: {
-        vcReleaseOnPath: false,
-      },
-    };
+    // specGroups["coded_mock_different_env_server"] = {
+    //   specs: ["./**/**/vcast_coded_test_different_envs_hover.test.ts"],
+    //   env: {
+    //     VECTORCAST_DIR: `/vcast/2024sp1:${process.env.HOME}/vcast/2024sp1`,
+    //     SWITCH_ENV_AT_THE_END: "True",
+    //   },
+    //   params: {
+    //     vcReleaseOnPath: false,
+    //   },
+    // };
 
     specGroups["import_coded_test_server"] = {
       specs: ["./**/**/vcast_coded_tests_relative_path.test.ts"],

--- a/tests/internal/e2e/test/specs_config.ts
+++ b/tests/internal/e2e/test/specs_config.ts
@@ -133,18 +133,6 @@ export function getSpecGroups(useVcast24: boolean) {
       params: {},
     };
 
-    // specGroups["coded_mock_different_env"] = {
-    //   specs: ["./**/**/vcast_coded_test_different_envs_hover.test.ts"],
-    //   env: {
-    //     VCAST_USE_PYTHON: "True",
-    //     VECTORCAST_DIR: `/vcast/2024sp1:${process.env.HOME}/vcast/2024sp1`,
-    //     SWITCH_ENV_AT_THE_END: "True",
-    //   },
-    //   params: {
-    //     vcReleaseOnPath: false,
-    //   },
-    // };
-
     specGroups["basic_user_interactions_server"] = {
       specs: [
         "./**/**/vcast.build_env.test.ts",
@@ -178,7 +166,7 @@ export function getSpecGroups(useVcast24: boolean) {
     specGroups["build_different_envs_server"] = {
       specs: ["./**/**/vcast_build_env_failure_different_paths.test.ts"],
       env: {
-        VECTORCAST_DIR: `/vcast/release23:${process.env.HOME}/vcast/release23`,
+        VECTORCAST_DIR: `/vcast/2023sp0:${process.env.HOME}/vcast/2023sp0`,
         BUILD_MULTIPLE_ENVS: "True",
       },
       params: {},
@@ -260,22 +248,11 @@ export function getSpecGroups(useVcast24: boolean) {
       params: {},
     };
 
-    // specGroups["coded_mock_different_env_server"] = {
-    //   specs: ["./**/**/vcast_coded_test_different_envs_hover.test.ts"],
-    //   env: {
-    //     VECTORCAST_DIR: `/vcast/2024sp1:${process.env.HOME}/vcast/2024sp1`,
-    //     SWITCH_ENV_AT_THE_END: "True",
-    //   },
-    //   params: {
-    //     vcReleaseOnPath: false,
-    //   },
-    // };
-
-    // specGroups["import_coded_test_server"] = {
-    //   specs: ["./**/**/vcast_coded_tests_relative_path.test.ts"],
-    //   env: { IMPORT_CODED_TEST_IN_TST: "True" },
-    //   params: {},
-    // };
+    specGroups["import_coded_test_server"] = {
+      specs: ["./**/**/vcast_coded_tests_relative_path.test.ts"],
+      env: { IMPORT_CODED_TEST_IN_TST: "True" },
+      params: {},
+    };
   }
 
   return specGroups;

--- a/tests/internal/e2e/test/specs_config.ts
+++ b/tests/internal/e2e/test/specs_config.ts
@@ -271,11 +271,11 @@ export function getSpecGroups(useVcast24: boolean) {
     //   },
     // };
 
-    specGroups["import_coded_test_server"] = {
-      specs: ["./**/**/vcast_coded_tests_relative_path.test.ts"],
-      env: { IMPORT_CODED_TEST_IN_TST: "True" },
-      params: {},
-    };
+    // specGroups["import_coded_test_server"] = {
+    //   specs: ["./**/**/vcast_coded_tests_relative_path.test.ts"],
+    //   env: { IMPORT_CODED_TEST_IN_TST: "True" },
+    //   params: {},
+    // };
   }
 
   return specGroups;

--- a/tests/internal/e2e/test/wdio.conf.ts
+++ b/tests/internal/e2e/test/wdio.conf.ts
@@ -808,9 +808,12 @@ ENVIRO.END
       const isServerRunnable = await checkForServerRunnability(
         clicastExecutablePath.trimEnd()
       );
+
       // Check if VCAST_USE_PYTHON is defined and if the server is runnable
-      const useDataServer =
-        process.env.VCAST_USE_PYTHON && isServerRunnable
+      // If the version is < 24sp4 ... we set the useDataServer false either way.
+      const useDataServer = !isServerRunnable
+        ? `"vectorcastTestExplorer.useDataServer": false`
+        : process.env.VCAST_USE_PYTHON
           ? `"vectorcastTestExplorer.useDataServer": false`
           : `"vectorcastTestExplorer.useDataServer": true`;
 

--- a/tests/internal/e2e/test/wdio.conf.ts
+++ b/tests/internal/e2e/test/wdio.conf.ts
@@ -449,6 +449,10 @@ export const config: Options.Testrunner = {
      * TARGET SPEC GROUP: coded_mock_different_env && import_coded_test
      */
     async function buildEnvsWithSpecificReleases(initialWorkdir: string) {
+      // Setup environment with clicast and vpython
+      await checkVPython();
+      let clicastExecutablePath: string;
+
       const workspacePath = path.join(__dirname, "vcastTutorial");
       const testInputVcastTutorial = path.join(
         initialWorkdir,
@@ -475,7 +479,8 @@ export const config: Options.Testrunner = {
         clicastExecutablePath = `${process.env.VECTORCAST_DIR}/clicast`;
         process.env.CLICAST_PATH = clicastExecutablePath;
       } else {
-        process.env.VECTORCAST_DIR = path.join(vcastRoot, newestVCRelease);
+        clicastExecutablePath = await checkClicast();
+        process.env.CLICAST_PATH = clicastExecutablePath;
       }
 
       await prepareConfig(initialWorkdir, clicastExecutablePath);
@@ -561,7 +566,7 @@ TEST.END`;
       await executeCommand(setEnviro);
       await executeCommand(runTest);
 
-      process.env.VECTORCAST_DIR = path.join(vcastRoot, newestVCRelease);
+      process.env.VECTORCAST_DIR = path.join(vcastRoot, "2024sp4");
     }
 
     /**
@@ -635,7 +640,7 @@ ENVIRO.END
         let envName: string;
         // Switch VectorCAST version based on iteration (build 1,3 --> release 23, 2,4 --> release 24)
         if (i % 2 === 0) {
-          process.env.VECTORCAST_DIR = path.join(vcastRoot, newestVCRelease);
+          process.env.VECTORCAST_DIR = path.join(vcastRoot, "2024sp4");
           envName = `ENV_24_${i.toString().padStart(2, "0")}`;
           console.log(`Building ${envName} with ${process.env.VECTORCAST_DIR}`);
         } else {
@@ -806,7 +811,7 @@ ENVIRO.END
       const settingsJsonPath = path.join(vscodeSettingsPath, "settings.json");
 
       const isServerRunnable = await checkForServerRunnability(
-        clicastExecutablePath.trimEnd()
+        clicastExecutablePath
       );
 
       // Check if VCAST_USE_PYTHON is defined and if the server is runnable
@@ -981,7 +986,7 @@ ENVIRO.END
         vcastRoot = "/vcast";
       } else {
         // Assuming that locally release is on this path.
-        vcastRoot = path.join(process.env.HOME, "vcast");
+        vcastRoot = path.join(".", process.env.HOME, "vcast");
       }
 
       return vcastRoot;

--- a/tests/internal/e2e/test/wdio.conf.ts
+++ b/tests/internal/e2e/test/wdio.conf.ts
@@ -810,7 +810,7 @@ ENVIRO.END
       );
       // Check if VCAST_USE_PYTHON is defined and if the server is runnable
       const useDataServer =
-        process.env.VCAST_USE_PYTHON && !isServerRunnable
+        process.env.VCAST_USE_PYTHON && isServerRunnable
           ? `"vectorcastTestExplorer.useDataServer": false`
           : `"vectorcastTestExplorer.useDataServer": true`;
 

--- a/tests/internal/e2e/test/wdio.conf.ts
+++ b/tests/internal/e2e/test/wdio.conf.ts
@@ -986,7 +986,7 @@ ENVIRO.END
         vcastRoot = "/vcast";
       } else {
         // Assuming that locally release is on this path.
-        vcastRoot = path.join(".", process.env.HOME, "vcast");
+        vcastRoot = path.join(process.env.HOME, "vcast");
       }
 
       return vcastRoot;

--- a/tests/unit/getToolversion.ts
+++ b/tests/unit/getToolversion.ts
@@ -126,31 +126,33 @@ export async function checkForServerRunnability(
 
   // Read and validate tool version from toolVersionPath
   try {
-    const toolVersion: string = fs
-      .readFileSync(toolVersionPath, "utf-8")
-      .trim();
-    const [majorVersionStr, spPart] = toolVersion.split(".sp");
+    const toolVersion: string = fs.readFileSync(toolVersionPath, "utf8").trim();
+
+    const [majorVersionString, spPart] = toolVersion.split(".sp");
 
     // The version number
-    const majorVersion = Number(majorVersionStr);
-    // Split away the date (4 (23/10/24) --> 4)
+    const majorVersion = Number(majorVersionString);
+
+    // Split away the date (e.g., "4 (08/26/24)" --> "4")
     const spVersion = Number(spPart.split(" ")[0]);
 
-    console.log(`Version: ${majorVersionStr}`);
+    console.log(`Version: ${majorVersionString}`);
     console.log(`Sub-Version: ${spVersion}`);
 
     // Check if major version and sp version meet the criteria
     if (majorVersion < 24 || (majorVersion === 24 && spVersion < 5)) {
       console.log(
-        `Version ${toolVersion} does not meet the minimum requirement of to run the clicast server (24sp5).`
+        `Version ${toolVersion} does not meet the minimum requirement to run the clicast server (24sp5).`
       );
       return false;
     }
+
     return true;
   } catch (error) {
     console.error(
       `Error reading tool version: ${error instanceof Error ? error.message : String(error)}`
     );
+
     return false;
   }
 }

--- a/tests/unit/getToolversion.ts
+++ b/tests/unit/getToolversion.ts
@@ -136,10 +136,13 @@ export async function checkForServerRunnability(
     // Split away the date (4 (23/10/24) --> 4)
     const spVersion = Number(spPart.split(" ")[0]);
 
+    console.log(`Version: ${majorVersionStr}`);
+    console.log(`Sub-Version: ${spVersion}`);
+
     // Check if major version and sp version meet the criteria
     if (majorVersion < 24 || (majorVersion === 24 && spVersion < 5)) {
       console.log(
-        `Version ${toolVersion} does not meet the minimum requirement of 24sp5.`
+        `Version ${toolVersion} does not meet the minimum requirement of to run the clicast server (24sp5).`
       );
       return false;
     }

--- a/tests/unit/getToolversion.ts
+++ b/tests/unit/getToolversion.ts
@@ -85,3 +85,67 @@ export async function getToolVersion(givenClicastPath?: string) {
     return Number.NaN;
   }
 }
+
+/**
+ * Function to get the clicast executable path and check if the tool version supports server runnability
+ */
+export async function checkForServerRunnability(
+  givenClicastPath?: string
+): Promise<boolean> {
+  let toolVersionPath = "";
+
+  // Set toolVersionPath based on given path or locate clicast executable
+  if (givenClicastPath) {
+    toolVersionPath = path.join(
+      givenClicastPath,
+      "..",
+      "DATA",
+      "tool_version.txt"
+    );
+  } else {
+    const checkClicast =
+      process.platform === "win32" ? "where clicast" : "which clicast";
+    try {
+      const { stdout, stderr } = await promisifiedExec(checkClicast);
+      if (stderr) throw new Error(`Error: make sure clicast is on PATH`);
+
+      const clicastExecutablePath = stdout.trim();
+      toolVersionPath = path.join(
+        clicastExecutablePath,
+        "..",
+        "DATA",
+        "tool_version.txt"
+      );
+    } catch (error) {
+      console.error(
+        `Error locating clicast: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return false;
+    }
+  }
+
+  // Read and validate tool version from toolVersionPath
+  try {
+    const toolVersion: string = fs
+      .readFileSync(toolVersionPath, "utf-8")
+      .trim();
+    const [majorVersionStr, spPart] = toolVersion.split(".sp");
+
+    const majorVersion = Number(majorVersionStr);
+    const spVersion = Number(spPart);
+
+    // Check if major version and sp version meet the criteria
+    if (majorVersion < 24 || (majorVersion === 24 && spVersion < 5)) {
+      console.log(
+        `Version ${toolVersion} does not meet the minimum requirement of 24sp5.`
+      );
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.error(
+      `Error reading tool version: ${error instanceof Error ? error.message : String(error)}`
+    );
+    return false;
+  }
+}

--- a/tests/unit/getToolversion.ts
+++ b/tests/unit/getToolversion.ts
@@ -131,8 +131,10 @@ export async function checkForServerRunnability(
       .trim();
     const [majorVersionStr, spPart] = toolVersion.split(".sp");
 
+    // The version number
     const majorVersion = Number(majorVersionStr);
-    const spVersion = Number(spPart);
+    // Split away the date (4 (23/10/24) --> 4)
+    const spVersion = Number(spPart.split(" ")[0]);
 
     // Check if major version and sp version meet the criteria
     if (majorVersion < 24 || (majorVersion === 24 && spVersion < 5)) {


### PR DESCRIPTION
## Summary

We had undetected problems with the CI, so the tests for releases > 24 did not get fetched. This PR is a hotfix for the tests to make them work for the changes on `clicast_server_release`. 

Also adds clicast server tests to CI