### PR TITLE
Increase minimum VS Code version from 1.78 to 1.79

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "vitest": "^0.32.2"
       },
       "engines": {
-        "vscode": "^1.78.0"
+        "vscode": "^1.79.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -678,6 +678,6 @@
   },
   "extensionDependencies": [],
   "engines": {
-    "vscode": "^1.78.0"
+    "vscode": "^1.79.0"
   }
 }

--- a/tests/internal/e2e/test/capabilityConfig.json
+++ b/tests/internal/e2e/test/capabilityConfig.json
@@ -1,7 +1,7 @@
 {
   "maxInstances": 1,
   "browserName": "vscode",
-  "browserVersion": "1.78.0",
+  "browserVersion": "1.79.0",
   "acceptInsecureCerts": true,
   "wdio:vscodeOptions": {
     "vscodeArgs": {


### PR DESCRIPTION
In preparation of #243, we need to increase the version of VS Code from 1.78 to 1.79.