### PR TITLE
Fixed wrong Test Results message log.

### DIFF
--- a/src/testPane.ts
+++ b/src/testPane.ts
@@ -40,6 +40,7 @@ import {
 
 import {
   addLaunchConfiguration,
+  cleanTestResultsPaneMessage,
   forceLowerCaseDriveLetter,
   loadLaunchFile,
   openFileWithLineSelected,
@@ -850,7 +851,11 @@ export async function runNode(
     const status = executionResult.status;
 
     // We show stdout from execution in the "Test Results" pane
-    run.appendOutput(executionResult.details.stdOut);
+    // We need to clean the string first because the logs in the Test Results pane are handled differently
+    let cleanedOutput = cleanTestResultsPaneMessage(
+      executionResult.details.stdOut
+    );
+    run.appendOutput(cleanedOutput);
 
     if (status == testStatus.didNotRun) {
       run.skipped(node);

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -305,3 +305,31 @@ export function removeFilePattern(enviroPath: string, pattern: string) {
     fs.unlinkSync(filePath);
   }
 }
+
+/**
+ * Cleans the message we want to show in the output. The Test Results pane handles logs differently.
+ * @param testResultString Test result we want to clean
+ * @returns Cleaned message, ready for the Test Results pane
+ */
+export function cleanTestResultsPaneMessage(testResultString: string) {
+  let cleanedOutput = testResultString.split("\n");
+
+  // Determine the leading spaces in the second line
+  // We want that the first line is left-aligned, and all subsequent lines are aligned to the second line
+  let secondLine = cleanedOutput[1] || "";
+  let secondLinePadding = secondLine.match(/^(\s*)/)?.[0] || "";
+
+  // Align all lines after the first one to match the second line's padding
+  let alignedOutput = cleanedOutput
+    .map((line, index) => {
+      // First line stays unmodified
+      if (index === 0) {
+        return line.trim();
+      }
+      // Apply second line padding to subsequent lines
+      return secondLinePadding + line.trim();
+    })
+    .join("\r\n");
+
+  return alignedOutput;
+}


### PR DESCRIPTION
The logs displayed in the Test Results pane were previously unstructured and inconsistent compared to the formatting in the normal Output message pane. This PR addresses the issue by ensuring that the logs in the Test Results pane are properly formatted.