### PR TITLE
Updated Tst autocompletion support for ct (Issue #170)

### DIFF
--- a/langServer/pythonUtilities.ts
+++ b/langServer/pythonUtilities.ts
@@ -101,7 +101,8 @@ export const emptyChoiceData: choiceDataType = {
 export async function getChoiceDataFromServer(
   kind: choiceKindType,
   enviroPath: string,
-  lineSoFar: string
+  lineSoFar: string,
+  unit?: string
 ): Promise<choiceDataType> {
   // We are re-using options for the line fragment in the request
 
@@ -113,6 +114,7 @@ export async function getChoiceDataFromServer(
     command: commandToUse,
     path: enviroPath,
     options: lineSoFar,
+    ...(unit !== undefined && { unit }), // only add unitName if it is defined
   };
 
   let transmitResponse: transmitResponseType =
@@ -138,11 +140,12 @@ export enum choiceKindType {
 export function getChoiceDataFromPython(
   kind: choiceKindType,
   enviroName: string,
-  lineSoFar: string
+  lineSoFar: string,
+  unit?: string
 ): choiceDataType {
   // NOTE: we cannot use executeCommand() here because it is in the client only!
   // commandOutput is a buffer: (Uint8Array)
-  const commandToRun = `${vPythonCommandToUse} ${testEditorScriptPath} ${kind} ${enviroName} "${lineSoFar}"`;
+  const commandToRun = `${vPythonCommandToUse} ${testEditorScriptPath} --mode ${kind} --enviroName ${enviroName} --inputLine "${lineSoFar}" --unit ${unit}`;
   let commandOutputBuffer = execSync(commandToRun).toString();
 
   // see detailed comment with the function definition
@@ -157,15 +160,16 @@ export function getChoiceDataFromPython(
 export async function getChoiceData(
   kind: choiceKindType,
   enviroPath: string,
-  lineSoFar: string
+  lineSoFar: string,
+  unit?: string
 ): Promise<choiceDataType> {
   //
 
   let jsonData: any;
   if (globalEnviroDataServerActive) {
-    jsonData = await getChoiceDataFromServer(kind, enviroPath, lineSoFar);
+    jsonData = await getChoiceDataFromServer(kind, enviroPath, lineSoFar, unit);
   } else {
-    jsonData = getChoiceDataFromPython(kind, enviroPath, lineSoFar);
+    jsonData = getChoiceDataFromPython(kind, enviroPath, lineSoFar, unit);
   }
 
   for (const msg of jsonData.messages) {

--- a/python/tstUtilities.py
+++ b/python/tstUtilities.py
@@ -413,6 +413,28 @@ class choiceDataType:
         return data
 
 
+def processSubprogramLines(api, pieces, triggerCharacter, unit):
+    """
+    This function will handle the TEST.SUBPROGRAM line completions
+    """
+    global globalOutputLog
+    returnData = choiceDataType()
+    lengthOfCommand = len(pieces)
+    globalOutputLog.append("Last piece: " + pieces[2])
+    globalOutputLog.append("pieces length: " + str(lengthOfCommand))
+    # TEST.SUBPROGRAM:
+    if lengthOfCommand == 3 and triggerCharacter == ":":
+        objectList = api.Unit.all()
+        returnData.choiceList = getFunctionList(api, unit)
+        returnData.choiceKind = choiceKindType.Function
+        returnData.choiceList.append("<<INIT>>")
+        returnData.choiceList.append("<<COMPOUND>>")
+    else:
+        # TODO: Current implementation just to make it work. --> See what alse can come after
+        processStandardLines(api, pieces, triggerCharacter)
+    return returnData
+
+
 def processRequirementLines(api, pieces, triggerCharacter):
     """
     This function will compute the list of possible requirement keys and return
@@ -985,7 +1007,7 @@ def buildChoiceResponse(choiceData: choiceDataType):
     return responseObject
 
 
-def processTstLine(enviroPath, line):
+def processTstLine(enviroPath, line, unit=None):
     """
 
     This function will process TEST.<command> line completions
@@ -1039,6 +1061,8 @@ def processTstLine(enviroPath, line):
             returnData = processSlotLines(api, pieces, triggerCharacter)
         elif line.upper().startswith("TEST.REQUIREMENT_KEY"):
             returnData = processRequirementLines(api, pieces, triggerCharacter)
+        elif line.upper().startswith("TEST.SUBPROGRAM"):
+            returnData = processSubprogramLines(api, pieces, triggerCharacter, unit)
         else:
             returnData = processStandardLines(api, pieces, triggerCharacter)
 

--- a/python/tstUtilities.py
+++ b/python/tstUtilities.py
@@ -427,8 +427,7 @@ def processSubprogramLines(api, pieces, triggerCharacter, unit):
         objectList = api.Unit.all()
         returnData.choiceList = getFunctionList(api, unit)
         returnData.choiceKind = choiceKindType.Function
-        returnData.choiceList.append("<<INIT>>")
-        returnData.choiceList.append("<<COMPOUND>>")
+        returnData.choiceList.extend(["<<INIT>>", "<<COMPOUND>>", "coded_tests_driver"])
     else:
         # TODO: Current implementation just to make it work. --> See what alse can come after
         processStandardLines(api, pieces, triggerCharacter)
@@ -1062,6 +1061,10 @@ def processTstLine(enviroPath, line, unit=None):
         elif line.upper().startswith("TEST.REQUIREMENT_KEY"):
             returnData = processRequirementLines(api, pieces, triggerCharacter)
         elif line.upper().startswith("TEST.SUBPROGRAM"):
+            if unit == None:
+                globalOutputLog.append(
+                    "Additional 'unit' parameter is requiered for TEST.SUBPROGRAM: autocompletion."
+                )
             returnData = processSubprogramLines(api, pieces, triggerCharacter, unit)
         else:
             returnData = processStandardLines(api, pieces, triggerCharacter)

--- a/python/vcastDataServer.py
+++ b/python/vcastDataServer.py
@@ -105,8 +105,11 @@ def runcommand(clientRequest, clientRequestText):
             # because we are not restarting, we need to clear the global output log
             testEditorInterface.globalOutputLog.clear()
 
+            logMessage(
+                f"  clientRequest '{clientRequest.options}' ###### '{clientRequest.path}' ##### '{clientRequest.unit}'"
+            )
             choiceData = testEditorInterface.processTstLine(
-                clientRequest.path, clientRequest.options
+                clientRequest.path, clientRequest.options, clientRequest.unit
             )
             returnData = tstUtilities.buildChoiceResponse(choiceData)
             logMessage(f"  line received: '{clientRequest.options}'")

--- a/python/vcastDataServerTypes.py
+++ b/python/vcastDataServerTypes.py
@@ -37,20 +37,27 @@ class commandType(str, Enum):
 
 
 class clientRequest:
-    def __init__(self, command, clicast="", path="", test="", options=""):
+    def __init__(
+        self,
+        command,
+        clicast="",
+        path="",
+        options="",
+        unit="",
+    ):
         self.command = command
         self.clicast = clicast
         self.path = path
-        self.test = test
         self.options = options
+        self.unit = unit
 
     def toDict(self):
         data = {}
         data["command"] = self.command
         data["clicast"] = self.clicast
         data["path"] = self.path
-        data["test"] = self.test
         data["options"] = self.options
+        data["unit"] = self.unit
         return data
 
     @classmethod
@@ -62,13 +69,13 @@ class clientRequest:
         clicast = ""
         if "clicast" in data:
             clicast = data["clicast"]
-        test = ""
-        if "test" in data:
-            test = data["test"]
         options = ""
         if "options" in data:
             options = data["options"]
-        return cls(command, clicast, path, test, options)
+        unit = ""
+        if "unit" in data:
+            unit = data["unit"]
+        return cls(command, clicast, path, options, unit)
 
 
 class environmentData:

--- a/src-common/vcastServer.ts
+++ b/src-common/vcastServer.ts
@@ -27,8 +27,8 @@ export enum vcastCommandType {
 export interface clientRequestType {
   command: vcastCommandType;
   path: string;
-  test?: string;
   options?: string;
+  unit?: string;
 }
 
 // This is set when the VectorCAST Data Server process is started

--- a/src/testPane.ts
+++ b/src/testPane.ts
@@ -40,6 +40,7 @@ import {
 
 import {
   addLaunchConfiguration,
+  cleanTestResultsPaneMessage,
   forceLowerCaseDriveLetter,
   loadLaunchFile,
   openFileWithLineSelected,
@@ -850,7 +851,11 @@ export async function runNode(
     const status = executionResult.status;
 
     // We show stdout from execution in the "Test Results" pane
-    run.appendOutput(executionResult.details.stdOut);
+    // We need to clean the string first because the logs in the Test Results pane are handled differently
+    let cleanedOutput = cleanTestResultsPaneMessage(
+      executionResult.details.stdOut
+    );
+    run.appendOutput(cleanedOutput);
 
     if (status == testStatus.didNotRun) {
       run.skipped(node);

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -305,3 +305,31 @@ export function removeFilePattern(enviroPath: string, pattern: string) {
     fs.unlinkSync(filePath);
   }
 }
+
+/**
+ * Cleans the message we want to show in the output. The Test Results pane handles logs differently.
+ * @param testResultString Test result we want to clean
+ * @returns Cleaned message, ready for the Test Results pane
+ */
+export function cleanTestResultsPaneMessage(testResultString: string) {
+  let cleanedOutput = testResultString.split("\n");
+
+  // Determine the leading spaces in the second line
+  // We want that the first line is left-aligned, and all subsequent lines are aligned to the second line
+  let secondLine = cleanedOutput[1] || "";
+  let secondLinePadding = secondLine.match(/^(\s*)/)?.[0] || "";
+
+  // Align all lines after the first one to match the second line's padding
+  let alignedOutput = cleanedOutput
+    .map((line, index) => {
+      // First line stays unmodified
+      if (index === 0) {
+        return line.trim();
+      }
+      // Apply second line padding to subsequent lines
+      return secondLinePadding + line.trim();
+    })
+    .join("\r\n");
+
+  return alignedOutput;
+}

--- a/syntax/vcast.tst.grammar.json
+++ b/syntax/vcast.tst.grammar.json
@@ -27,6 +27,24 @@
       }
     },
     {
+      "match": "^TEST\\.CODED_TEST_FILE(:)(.*?)(:|$)(.*)$",
+      "name": "keyword",
+      "captures": {
+        "1": {
+          "name": "keyword"
+        },
+        "2": {
+          "name": "string", 
+          "patterns": [
+            {
+              "match": "(\\.\\./|\\./|/)?[^\\s]*",
+              "name": "path"
+            }
+          ]
+        }     
+      }
+    },
+    {
       "match": "^TEST\\.(?:VALUE|EXPECTED)(:)(.*?)(?<!:)(:|$)(?!:)(.*)$",
       "name": "keyword",
       "captures": {

--- a/tests/unit/setup-unit-test.ts
+++ b/tests/unit/setup-unit-test.ts
@@ -13,7 +13,6 @@ module.exports = async () => {
   // If PACKAGE_PATH is already defined by vscode launch.json (debugger) --> Don't override it
   process.env.PACKAGE_PATH ??= process.env.INIT_CWD;
   process.env.TST_FILENAME = tstFilename;
-  process.env.VECTORCAST_DIR = "";
 
   const checkVpython: string =
     process.platform === "win32" ? "where vpython" : "which vpython";

--- a/tests/unit/tst-completion.test.ts
+++ b/tests/unit/tst-completion.test.ts
@@ -147,6 +147,17 @@ TEST.NOTES:
 TEST.END_NOTES:
 TEST.END`;
 
+const suprogrammWithoutCTDriver = `-- Environment: @TEST
+TEST.UNIT:
+TEST.SUBPROGRAM:bar
+TEST.NEW
+TEST.CODED_TEST_FILE:
+TEST.NAME:
+TEST.VALUE:
+TEST.NOTES: 
+TEST.END_NOTES:
+TEST.END`;
+
 describe("Text Completion", () => {
   test(
     "validate tst completion for TEST.SUBPROGRAM:",
@@ -167,22 +178,28 @@ describe("Text Completion", () => {
 
       expect(generatedCompletionData).toEqual([
         {
-          label: "<<INIT>>",
-          kind: 3,
-          detail: "",
           data: 0,
-        },
-        {
-          label: "<<COMPOUND>>",
-          kind: 3,
           detail: "",
-          data: 1,
-        },
-        {
+          kind: 3,
           label: "bar",
-          kind: 3,
+        },
+        {
+          data: 1,
           detail: "",
+          kind: 3,
+          label: "<<INIT>>",
+        },
+        {
           data: 2,
+          detail: "",
+          kind: 3,
+          label: "<<COMPOUND>>",
+        },
+        {
+          data: 3,
+          detail: "",
+          kind: 3,
+          label: "coded_tests_driver",
         },
       ]);
     },
@@ -1001,19 +1018,25 @@ describe("Text Completion", () => {
           data: 0,
           detail: "",
           kind: 3,
-          label: "<<INIT>>",
+          label: "bar",
         },
         {
           data: 1,
           detail: "",
           kind: 3,
-          label: "<<COMPOUND>>",
+          label: "<<INIT>>",
         },
         {
           data: 2,
           detail: "",
           kind: 3,
-          label: "bar",
+          label: "<<COMPOUND>>",
+        },
+        {
+          data: 3,
+          detail: "",
+          kind: 3,
+          label: "coded_tests_driver",
         },
       ]);
     },
@@ -1058,19 +1081,25 @@ describe("Text Completion", () => {
           data: 0,
           detail: "",
           kind: 3,
-          label: "<<INIT>>",
+          label: "bar",
         },
         {
           data: 1,
           detail: "",
           kind: 3,
-          label: "<<COMPOUND>>",
+          label: "<<INIT>>",
         },
         {
           data: 2,
           detail: "",
           kind: 3,
-          label: "bar",
+          label: "<<COMPOUND>>",
+        },
+        {
+          data: 3,
+          detail: "",
+          kind: 3,
+          label: "coded_tests_driver",
         },
       ]);
     },
@@ -1097,19 +1126,25 @@ describe("Text Completion", () => {
           data: 0,
           detail: "",
           kind: 3,
-          label: "<<INIT>>",
+          label: "bar",
         },
         {
           data: 1,
           detail: "",
           kind: 3,
-          label: "<<COMPOUND>>",
+          label: "<<INIT>>",
         },
         {
           data: 2,
           detail: "",
           kind: 3,
-          label: "bar",
+          label: "<<COMPOUND>>",
+        },
+        {
+          data: 3,
+          detail: "",
+          kind: 3,
+          label: "coded_tests_driver",
         },
       ]);
     },
@@ -1261,6 +1296,27 @@ describe("Text Completion", () => {
           data: 3,
         },
       ]);
+    },
+    timeout
+  );
+
+  test(
+    "validate that TEST.CODED_TEST_FILE has no autocompletion.",
+    async () => {
+      const tstText = suprogrammWithoutCTDriver;
+      const lineToComplete = "TEST.CODED_TEST_FILE:";
+      const completionPosition = getCompletionPositionForLine(
+        lineToComplete,
+        tstText
+      );
+      const triggerCharacter = lineToComplete.at(-1);
+
+      const generatedCompletionData = await generateCompletionData(
+        tstText,
+        completionPosition,
+        triggerCharacter
+      );
+      expect(generatedCompletionData).toEqual([]);
     },
     timeout
   );


### PR DESCRIPTION
## Summary

Updates script editing to support coded tests and resolves #170. 

## Added
- **Syntax Support for `TEST.CODED_TEST_FILE`:**
  - Added `TEST.CODED_TEST_FILE` as a valid syntax in `.tst` files.
  - Enabled auto-complete for `TEST.CODED_TEST_FILE` after typing `TEST.`.
  - Ensured no auto-completion for the file path after `:`.

- **Behavior When `TEST.SUBPROGRAM` is `coded_tests_driver`:**
  - Allowed `TEST.CODED_TEST_FILE` without error diagnostics.
  - Disallowed `TEST.VALUE` and `TEST.EXPECTED` lines, ensuring they give error diagnostics.

- **Behavior When `TEST.SUBPROGRAM` is Not `coded_tests_driver`:**
  - Disallowed `TEST.CODED_TEST_FILE`, ensuring it gives an error diagnostic.
  - Removed `coded_tests_driver` from the subprogram list for `TEST.VALUE` and `TEST.EXPECTED` lines.

- **Error Handling Enhancements:**
  - Reviewed and ensured consistency in error messages related to these changes.

- **Tests**
   - Added tests for new diagnostics

- **Autocompletion list for `TEST.SUBPROGRAM`** without using the fake `TEST.VALUE` line 
  - In order to get the autocompletion list for `TEST.SUBPROGRAM`, we need the `<unit>` from `TEST.UNIT`.
  - This is retrieved with `getNearest()` in `tstCompletion.ts`.
  - This `<unit>` is sent as an additional parameter to the Python logic.
  - In `processSubprogramLines()` (tstUtilities.py), we use this `<unit>` to retrieve, with `getFunctions()`, the `autocompletion` list of all the functions in this unit from the `DataAPI`.
  - At the end, we add SUBPROGRAM-specific autocompletions like `<<INIT>>, <<COMPOUND>>, <<coded_tests_driver>>`.