### PR TITLE
Fixing new env in blank project issue

### DIFF
--- a/src/vcastUtilities.ts
+++ b/src/vcastUtilities.ts
@@ -573,6 +573,15 @@ export function checkIfAnyProjectsAreOpened() {
       return true;
     }
   }
+
+  // In case we have empty projects without envs in it
+  if (
+    typeof globalProjectDataCache !== "undefined" &&
+    globalProjectDataCache.size > 0
+  ) {
+    return true;
+  }
+
   return false;
 }
 


### PR DESCRIPTION
There was an issue where when you create a fresh project without any existing environments in the workspace or the project, we cannot build a new env into that project as the button did not appear. 