### PR TITLE
Fix search for reqs2x executable on Windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,6 +76,7 @@ import {
   forceLowerCaseDriveLetter,
   decodeVar,
   normalizePath,
+  exeFilename,
 } from "./utilities";
 
 import {
@@ -253,8 +254,8 @@ function getAutoreqExecutableDirectory(
   context: vscode.ExtensionContext
 ): vscode.Uri | undefined {
   const pathHasAllExecutables = (dirPath: string): boolean => {
-    return NECCESSARY_REQS2X_EXECUTABLES.every((exe) =>
-      fs.existsSync(vscode.Uri.joinPath(vscode.Uri.file(dirPath), exe).fsPath)
+    return NECCESSARY_REQS2X_EXECUTABLES.every((exe) => 
+      fs.existsSync(vscode.Uri.joinPath(vscode.Uri.file(dirPath), exeFilename(exe)).fsPath)
     );
   };
 
@@ -310,13 +311,13 @@ function setupReqs2XExecutablePaths(context: vscode.ExtensionContext): boolean {
     return false;
   }
 
-  CODE2REQS_EXECUTABLE_PATH = vscode.Uri.joinPath(baseUri, "code2reqs").fsPath;
+  CODE2REQS_EXECUTABLE_PATH = vscode.Uri.joinPath(baseUri, exeFilename("code2reqs")).fsPath;
   REQS2TESTS_EXECUTABLE_PATH = vscode.Uri.joinPath(
     baseUri,
-    "reqs2tests"
+    exeFilename("reqs2tests")
   ).fsPath;
-  PANREQ_EXECUTABLE_PATH = vscode.Uri.joinPath(baseUri, "panreq").fsPath;
-  LLM2CHECK_EXECUTABLE_PATH = vscode.Uri.joinPath(baseUri, "llm2check").fsPath;
+  PANREQ_EXECUTABLE_PATH = vscode.Uri.joinPath(baseUri, exeFilename("panreq")).fsPath;
+  LLM2CHECK_EXECUTABLE_PATH = vscode.Uri.joinPath(baseUri, exeFilename("llm2check")).fsPath;
 
   return true;
 }


### PR DESCRIPTION
Properly looks for <executable>.exe on windows instead of just <executable>.