### PR TITLE
Small fixes regarding high-level requirement generation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3148,7 +3148,7 @@ function generateRequirementsHtml(requirements: any[]): string {
   // Group requirements by function
   const requirementsByFunction: Record<string, any[]> = {};
   for (const req of requirements) {
-    const funcName = req.Function || "Unknown Function";
+    const funcName = req.Function || req.Module || "Unknown Function";
     if (!requirementsByFunction[funcName]) {
       requirementsByFunction[funcName] = [];
     }


### PR DESCRIPTION
Corrects the config location used for determining if we should generate high-level requirements and adds the requirement module/unit as a backup group to group requirements under before falling back to "Unknown Function".