### PR TITLE
Expanding coded test file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "vectorcastTestExplorer" extension will be documented in this file.
 
+## [1.0.25] - 2025-11-20
+
+### Added
+- Added support for environment variable expansion in TEST.CODED_TESTS_FILE paths.
+
 ## [1.0.24] - 2025-11-14
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vectorcasttestexplorer",
   "displayName": "VectorCAST Test Explorer",
   "description": "VectorCAST Test Explorer for VS Code",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/python/pythonUtilities.py
+++ b/python/pythonUtilities.py
@@ -212,7 +212,9 @@ def monkeypatch_custom_css(custom_css):
     # Replace existing get_option with our one
     EnvironmentMixin.get_option = new_get_opt
 
+
 env_var_pattern = re.compile(r"\$\((.*?)\)")
+
 
 def expand_vc_env_vars(path: str) -> str:
     """

--- a/python/vTestInterface.py
+++ b/python/vTestInterface.py
@@ -162,21 +162,22 @@ def generateTestInfo(enviroPath, test):
         # or dataAPI has a bad line number for the test, and return None in this case.
         enclosingDirectory = os.path.dirname(enviroPath)
 
-        # If coded_tests_file uses $(VAR), expand it. 
+        # If coded_tests_file uses $(VAR), expand it.
         expanded_path = expand_vc_env_vars(test.coded_tests_file)
 
         # construct absolute path:
         if os.path.isabs(expanded_path):
             codedTestFilePath = os.path.abspath(expanded_path)
         else:
-            codedTestFilePath = os.path.abspath(os.path.join(enclosingDirectory, expanded_path))
+            codedTestFilePath = os.path.abspath(
+                os.path.join(enclosingDirectory, expanded_path)
+            )
 
         if os.path.exists(codedTestFilePath) and test.coded_tests_line > 0:
             testInfo["codedTestFile"] = codedTestFilePath
             testInfo["codedTestLine"] = test.coded_tests_line
         else:
             testInfo = None
-
 
     return testInfo
 
@@ -867,7 +868,6 @@ def processCommandLogic(mode, clicast, pathToUse, testString="", options=""):
         # file and generate the test list.
         expanded_path = expand_vc_env_vars(pathToUse)
         returnObject = getCodeBasedTestNames(expanded_path)
-
 
     elif mode == "rebuild":
         # Rebuild environment has some special processing because we want


### PR DESCRIPTION
In case the imported coded test file includes a VectorCAST env var in the path, the path gets expanded. Connected with issue #267 and fixes it.