### PR TITLE
Sourcefile open from testing pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the "vectorcastTestExplorer" extension will be documented in this file.
 
+## [1.0.28] - 2026-01-27
+
+### Added
+- Added possibility to open up multiple workdpace folders
+- Added Button to open up a Source File under Test from the Testing Pane
+
 ## [1.0.27] - 2025-12-15
 
 ### Bug fixes

--- a/package.json
+++ b/package.json
@@ -1077,7 +1077,7 @@
       },
       {
         "command": "vectorcastTestExplorer.openSourceFileFromTestpaneCommand",
-        "group": "vcast.testGeneration",
+        "group": "vcast.enviroManagement",
         "when": "testId =~ /^vcast:.*$/ && !(testId =~ /^.*<<COMPOUND>>.*$/) && !(testId =~ /^.*<<INIT>>.*$/) && !(testId =~ /.*coded_tests_driver.*/) && testId not in vectorcastTestExplorer.vcastUnbuiltEnviroList && testId not in vectorcastTestExplorer.vcastEnviroList"
       },
       {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vectorcasttestexplorer",
   "displayName": "VectorCAST Test Explorer",
   "description": "VectorCAST Test Explorer for VS Code",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -225,6 +225,11 @@
         "title": "Remove Coded Tests"
       },
       {
+        "command": "vectorcastTestExplorer.openSourceFileFromTestpaneCommand",
+        "category": "VectorCAST Test Explorer",
+        "title": "Open Source File under Test"
+      },
+      {
         "command": "vectorcastTestExplorer.insertBasisPathTests",
         "category": "VectorCAST Test Explorer",
         "title": "Insert Basis Path Tests"
@@ -764,6 +769,10 @@
           "when": "never"
         },
         {
+          "command": "vectorcastTestExplorer.openSourceFileFromTestpaneCommand",
+          "when": "never"
+        },
+        {
           "command": "vectorcastTestExplorer.insertBasisPathTests",
           "when": "never"
         },
@@ -1065,6 +1074,11 @@
         "command": "vectorcastTestExplorer.removeCodedTests",
         "group": "vcast.testScript",
         "when": "testId =~ /^vcast:.*$/ && testId =~ /.*coded_tests_driver$/ && testId in vectorcastTestExplorer.vcastHasCodedTestsList"
+      },
+      {
+        "command": "vectorcastTestExplorer.openSourceFileFromTestpaneCommand",
+        "group": "vcast.testGeneration",
+        "when": "testId =~ /^vcast:.*$/ && !(testId =~ /^.*<<COMPOUND>>.*$/) && !(testId =~ /^.*<<INIT>>.*$/) && !(testId =~ /.*coded_tests_driver.*/) && testId not in vectorcastTestExplorer.vcastUnbuiltEnviroList && testId not in vectorcastTestExplorer.vcastEnviroList"
       },
       {
         "command": "vectorcastTestExplorer.insertBasisPathTests",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -89,6 +89,7 @@ import {
   rebuildEnvironment,
   openProjectInVcast,
   deleteLevel,
+  getDataForEnvironment,
 } from "./vcastAdapter";
 
 import {
@@ -1234,6 +1235,49 @@ function configureExtension(context: vscode.ExtensionContext) {
     }
   );
   context.subscriptions.push(getMCDCReportCommand);
+
+  // Command: vectorcastTestExplorer.insertBasisPathTestsFromEditor////////////////////////////////////////////////////////
+  let openSourceFileFromTestpaneCommand = vscode.commands.registerCommand(
+    "vectorcastTestExplorer.openSourceFileFromTestpaneCommand",
+    async (args: any) => {
+      if (args) {
+        const testNode: testNodeType = getTestNode(args.id);
+        if (testNode) {
+          const enviroPath = testNode.enviroPath;
+          const unitName = testNode.unitName;
+          // Get the environment data
+          const envData = await getDataForEnvironment(enviroPath);
+
+          if (envData && envData.unitData) {
+            for (const unitInfo of envData.unitData) {
+              if (unitInfo.path) {
+                // Extract unit name from path to match against unitName
+                const pathBasename = path.basename(
+                  unitInfo.path,
+                  path.extname(unitInfo.path)
+                );
+                if (pathBasename === unitName) {
+                  const sourcePath = unitInfo.path;
+                  const uri = vscode.Uri.file(sourcePath);
+
+                  vscode.window.showTextDocument(uri, {
+                    preview: false, // open as a real tab
+                    preserveFocus: false,
+                  });
+                  console.log(`Source file for ${unitName}: ${sourcePath}`);
+                  break;
+                }
+              }
+            }
+          }
+        } else
+          vscode.window.showErrorMessage(
+            `Unable to open Source File for Node: ${args.id}`
+          );
+      }
+    }
+  );
+  context.subscriptions.push(openSourceFileFromTestpaneCommand);
 
   let showRequirementsCommand = vscode.commands.registerCommand(
     "vectorcastTestExplorer.showRequirements",

--- a/src/testPane.ts
+++ b/src/testPane.ts
@@ -57,7 +57,7 @@ import {
 import {
   deleteSingleTest,
   getCBTNamesFromFile,
-  getDataForEnvironment,
+  getDataForEnvironmentFromAPI,
   getDataForProject,
   getWorkspaceEnvDataVPython,
   loadTestScriptIntoEnvironment,
@@ -753,11 +753,11 @@ async function loadEnviroData(
       }
     } else {
       // Fallback in case the cache is not build, but it should be
-      return await getDataForEnvironment(buildPathDir);
+      return await getDataForEnvironmentFromAPI(buildPathDir);
     }
   } else {
     // Individual environment fetch (e.g. adding new test scripts, coded tests, ...)
-    return await getDataForEnvironment(buildPathDir);
+    return await getDataForEnvironmentFromAPI(buildPathDir);
   }
   // We have a valid build directory, but we couldn't find a matching VCE file in the workspace data.
   vectorMessage(

--- a/src/testPane.ts
+++ b/src/testPane.ts
@@ -703,7 +703,7 @@ let vcastHasCodedTestsList: string[] = [];
 
 // Global cache for workspace-wide env data
 // Used to avoid redundant API calls during refresh
-let cachedWorkspaceEnvData: CachedWorkspaceData | null = null;
+export let cachedWorkspaceEnvData: CachedWorkspaceData | null = null;
 
 export function clearCachedWorkspaceEnvData(): void {
   cachedWorkspaceEnvData = null;
@@ -950,6 +950,7 @@ async function loadAllVCTests(
   vcastUnbuiltEnviroList = [];
   clearEnviroDataCache();
   clearTestNodeCache();
+  clearCachedWorkspaceEnvData();
 
   // Resets the "used" and empty/unused compilers / testsuites
   clearGlobalCompilersAndTestsuites();
@@ -1015,7 +1016,6 @@ async function loadAllVCTests(
   // end if workspace folders
 
   checkWorkspaceEnvDataForErrors();
-  clearCachedWorkspaceEnvData();
 
   // In case we have empty testsuites or compilers in the project,
   // we won't find them in the Env data so we have to add them manually here

--- a/src/vcastAdapter.ts
+++ b/src/vcastAdapter.ts
@@ -636,7 +636,9 @@ function getProjectDataFromPython(projectDirectoryPath: string): any {
 
 // Get Environment Data ---------------------------------------------------------------
 // Server logic is in a separate function below
-export async function getDataForEnvironment(enviroPath: string): Promise<any> {
+export async function getDataForEnvironmentFromAPI(
+  enviroPath: string
+): Promise<any> {
   // what we get back is a JSON formatted string (if the command works)
   // that has two sub-fields: testData, and unitData
   vectorMessage("Processing environment data for: " + enviroPath);

--- a/src/vcastUtilities.ts
+++ b/src/vcastUtilities.ts
@@ -24,6 +24,7 @@ import {
 
 import {
   dumpTestScriptFile,
+  getDataForEnvironmentFromAPI,
   openProjectInVcast,
   runATGCommands,
   runBasisPathCommands,
@@ -43,6 +44,7 @@ import {
 
 import { clientRequestType, vcastCommandType } from "../src-common/vcastServer";
 import {
+  cachedWorkspaceEnvData,
   globalController,
   globalProjectDataCache,
   globalProjectMap,
@@ -837,4 +839,30 @@ export function getLevelFromNodeId(path: string) {
   const level = path.substring(remainderStart);
 
   return { projectName, level };
+}
+
+/**
+ * Retrieves Environment Data from the Cache or by asking the API if the cache
+ * is empty
+ * @param enviroPath Path of Environment
+ */
+export async function getEnvironmentData(enviroPath: string) {
+  // Add .vce extension to enviroPath for cache key
+  const cacheKey = enviroPath.endsWith(".vce")
+    ? enviroPath
+    : `${enviroPath}.vce`;
+
+  // Try to get data from cache first
+  let envData = null;
+  if (cachedWorkspaceEnvData) {
+    envData =
+      cachedWorkspaceEnvData[cacheKey as keyof typeof cachedWorkspaceEnvData];
+  }
+
+  // If not in cache, fetch it
+  if (!envData) {
+    envData = await getDataForEnvironmentFromAPI(enviroPath);
+  }
+
+  return envData;
 }

--- a/tests/internal/e2e/test/specs/vcast_mcdc_report.test.ts
+++ b/tests/internal/e2e/test/specs/vcast_mcdc_report.test.ts
@@ -160,7 +160,6 @@ describe("vTypeCheck VS Code Extension", () => {
 
     // Verify the cursor is on line 74 (the start of Manager::GetCheckTotal)
     expect(coordinates[0]).toBe(74);
-    await editorView.closeAllEditors();
   });
 
   it("should change coverageKind and Rebuild env", async () => {

--- a/tests/internal/e2e/test/specs/vcast_mcdc_report.test.ts
+++ b/tests/internal/e2e/test/specs/vcast_mcdc_report.test.ts
@@ -95,73 +95,6 @@ describe("vTypeCheck VS Code Extension", () => {
     );
   });
 
-  it("should open source file and focus on function start line when clicking 'Open Source File under Test' on function", async () => {
-    const workbench = await browser.getWorkbench();
-    const editorView = workbench.getEditorView();
-
-    // Close any open editors to ensure clean state
-    await editorView.closeAllEditors();
-
-    // Navigate to Testing pane and find the manager unit
-    const vcastTestingViewContent = await getViewContent("Testing");
-    let managerUnit: TreeItem | undefined;
-
-    for (const vcastTestingViewSection of await vcastTestingViewContent.getSections()) {
-      if (!(await vcastTestingViewSection.isExpanded())) {
-        await vcastTestingViewSection.expand();
-      }
-      managerUnit = await findSubprogram("manager", vcastTestingViewSection);
-      if (managerUnit) {
-        break;
-      }
-    }
-
-    if (!managerUnit) {
-      throw new Error("Unit 'manager' not found in Testing pane");
-    }
-
-    // Expand the manager unit to see its functions
-    if (!(await managerUnit.isExpanded())) {
-      await managerUnit.expand();
-    }
-
-    // Find the Manager::GetCheckTotal function
-    const getCheckTotalMethod = await findSubprogramMethod(
-      managerUnit,
-      "Manager::GetCheckTotal"
-    );
-
-    if (!getCheckTotalMethod) {
-      throw new Error("Function 'Manager::GetCheckTotal' not found");
-    }
-
-    // Open the source file through the context menu on the function
-    const contextMenu = await getCheckTotalMethod.openContextMenu();
-    await contextMenu.select("VectorCAST");
-    await (await $("aria/Open Source File under Test")).click();
-
-    // Wait for the file to open
-    await browser.waitUntil(
-      async () => {
-        const titles = await editorView.getOpenEditorTitles();
-        return titles.includes("manager.cpp");
-      },
-      {
-        timeout: TIMEOUT,
-        timeoutMsg: "File manager.cpp did not open within timeout",
-      }
-    );
-
-    // Open/get the active editor
-    const tab = (await editorView.openEditor("manager.cpp")) as TextEditor;
-
-    // Get the current cursor position
-    const coordinates = await tab.getCoordinates();
-
-    // Verify the cursor is on line 74 (the start of Manager::GetCheckTotal)
-    expect(coordinates[0]).toBe(74);
-  });
-
   it("should change coverageKind and Rebuild env", async () => {
     // We need to change the covarage kind to Statement+MCDC in order to get the MCDC lines
     let settingsEditor = await workbench.openSettings();
@@ -601,5 +534,72 @@ describe("vTypeCheck VS Code Extension", () => {
     await expect(await checkElementExistsInHTML("15")).toBe(true);
 
     await webview.close();
+  });
+
+  it("should open source file and focus on function start line when clicking 'Open Source File under Test' on function", async () => {
+    const workbench = await browser.getWorkbench();
+    const editorView = workbench.getEditorView();
+
+    // Close any open editors to ensure clean state
+    await editorView.closeAllEditors();
+
+    // Navigate to Testing pane and find the manager unit
+    const vcastTestingViewContent = await getViewContent("Testing");
+    let managerUnit: TreeItem | undefined;
+
+    for (const vcastTestingViewSection of await vcastTestingViewContent.getSections()) {
+      if (!(await vcastTestingViewSection.isExpanded())) {
+        await vcastTestingViewSection.expand();
+      }
+      managerUnit = await findSubprogram("manager", vcastTestingViewSection);
+      if (managerUnit) {
+        break;
+      }
+    }
+
+    if (!managerUnit) {
+      throw new Error("Unit 'manager' not found in Testing pane");
+    }
+
+    // Expand the manager unit to see its functions
+    if (!(await managerUnit.isExpanded())) {
+      await managerUnit.expand();
+    }
+
+    // Find the Manager::GetCheckTotal function
+    const getCheckTotalMethod = await findSubprogramMethod(
+      managerUnit,
+      "Manager::GetCheckTotal"
+    );
+
+    if (!getCheckTotalMethod) {
+      throw new Error("Function 'Manager::GetCheckTotal' not found");
+    }
+
+    // Open the source file through the context menu on the function
+    const contextMenu = await getCheckTotalMethod.openContextMenu();
+    await contextMenu.select("VectorCAST");
+    await (await $("aria/Open Source File under Test")).click();
+
+    // Wait for the file to open
+    await browser.waitUntil(
+      async () => {
+        const titles = await editorView.getOpenEditorTitles();
+        return titles.includes("manager.cpp");
+      },
+      {
+        timeout: TIMEOUT,
+        timeoutMsg: "File manager.cpp did not open within timeout",
+      }
+    );
+
+    // Open/get the active editor
+    const tab = (await editorView.openEditor("manager.cpp")) as TextEditor;
+
+    // Get the current cursor position
+    const coordinates = await tab.getCoordinates();
+
+    // Verify the cursor is on line 74 (the start of Manager::GetCheckTotal)
+    expect(coordinates[0]).toBe(74);
   });
 });

--- a/tests/internal/e2e/test/specs/vcast_mcdc_report.test.ts
+++ b/tests/internal/e2e/test/specs/vcast_mcdc_report.test.ts
@@ -5,6 +5,7 @@ import {
   CustomTreeItem,
   EditorView,
   TreeItem,
+  TextEditor,
 } from "wdio-vscode-service";
 import { Key } from "webdriverio";
 import {
@@ -92,6 +93,74 @@ describe("vTypeCheck VS Code Extension", () => {
           .includes("Starting the language server"),
       { timeout: TIMEOUT }
     );
+  });
+
+  it("should open source file and focus on function start line when clicking 'Open Source File under Test' on function", async () => {
+    const workbench = await browser.getWorkbench();
+    const editorView = workbench.getEditorView();
+
+    // Close any open editors to ensure clean state
+    await editorView.closeAllEditors();
+
+    // Navigate to Testing pane and find the manager unit
+    const vcastTestingViewContent = await getViewContent("Testing");
+    let managerUnit: TreeItem | undefined;
+
+    for (const vcastTestingViewSection of await vcastTestingViewContent.getSections()) {
+      if (!(await vcastTestingViewSection.isExpanded())) {
+        await vcastTestingViewSection.expand();
+      }
+      managerUnit = await findSubprogram("manager", vcastTestingViewSection);
+      if (managerUnit) {
+        break;
+      }
+    }
+
+    if (!managerUnit) {
+      throw new Error("Unit 'manager' not found in Testing pane");
+    }
+
+    // Expand the manager unit to see its functions
+    if (!(await managerUnit.isExpanded())) {
+      await managerUnit.expand();
+    }
+
+    // Find the Manager::GetCheckTotal function
+    const getCheckTotalMethod = await findSubprogramMethod(
+      managerUnit,
+      "Manager::GetCheckTotal"
+    );
+
+    if (!getCheckTotalMethod) {
+      throw new Error("Function 'Manager::GetCheckTotal' not found");
+    }
+
+    // Open the source file through the context menu on the function
+    const contextMenu = await getCheckTotalMethod.openContextMenu();
+    await contextMenu.select("VectorCAST");
+    await (await $("aria/Open Source File under Test")).click();
+
+    // Wait for the file to open
+    await browser.waitUntil(
+      async () => {
+        const titles = await editorView.getOpenEditorTitles();
+        return titles.includes("manager.cpp");
+      },
+      {
+        timeout: TIMEOUT,
+        timeoutMsg: "File manager.cpp did not open within timeout",
+      }
+    );
+
+    // Open/get the active editor
+    const tab = (await editorView.openEditor("manager.cpp")) as TextEditor;
+
+    // Get the current cursor position
+    const coordinates = await tab.getCoordinates();
+
+    // Verify the cursor is on line 74 (the start of Manager::GetCheckTotal)
+    expect(coordinates[0]).toBe(74);
+    await editorView.closeAllEditors();
   });
 
   it("should change coverageKind and Rebuild env", async () => {

--- a/tests/internal/e2e/test/test_utils/vcast_utils.ts
+++ b/tests/internal/e2e/test/test_utils/vcast_utils.ts
@@ -1612,6 +1612,18 @@ export async function checkForGutterAndGenerateReport(
     const contextMenu = await unit.openContextMenu();
     await contextMenu.select("VectorCAST");
     await (await $("aria/Open Source File under Test")).click();
+
+    // Wait for the file to actually open in the editor
+    await browser.waitUntil(
+      async () => {
+        const titles = await editorView.getOpenEditorTitles();
+        return titles.includes(unitFileName);
+      },
+      {
+        timeout: TIMEOUT,
+        timeoutMsg: `File ${unitFileName} did not open within timeout`,
+      }
+    );
   }
 
   const tab = (await editorView.openEditor(unitFileName)) as TextEditor;


### PR DESCRIPTION
Adds the Feature to open up a Source File from the Testing pane by either clicking on the unit or clikcing on a function within the units that also opens up the source file and focuses on where the function starts