### PR TITLE
Improved error handling during initial buildup of workspace cache

### DIFF
--- a/src/testPane.ts
+++ b/src/testPane.ts
@@ -778,8 +778,13 @@ async function buildEnvDataCacheForCurrentDir() {
     folderPaths.map((p) => getWorkspaceEnvDataVPython(p))
   );
 
+  // Filter out undefined/null responses (already logged by getWorkspaceEnvDataVPython)
+  const validResponses = responses.filter(
+    (r): r is CachedWorkspaceData => r != null
+  );
+
   // Merge them
-  cachedWorkspaceEnvData = await mergeWorkspaceEnvResponses(responses);
+  cachedWorkspaceEnvData = await mergeWorkspaceEnvResponses(validResponses);
 }
 
 /**

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -430,6 +430,7 @@ export async function mergeWorkspaceEnvResponses(
   const allEnvs: EnviroData[] = [];
 
   for (const resp of responses) {
+    if (!resp) continue;
     if (resp.errors) {
       allErrors.push(...resp.errors);
     }

--- a/src/vcastAdapter.ts
+++ b/src/vcastAdapter.ts
@@ -710,7 +710,15 @@ export async function getWorkspaceEnvDataVPython(
   );
   let jsonData = getJsonDataFromTestInterface(commandToRun, workspaceDir);
 
-  vectorMessage(`Building environments data for workspace: ${workspaceDir}`);
+  if (jsonData == null) {
+    vectorMessage(
+      `Failed to retrieve environment data for workspace folder: "${workspaceDir}". ` +
+        `The vpython command returned no data (possibly missing VectorCAST installation, ` +
+        `invalid environment, or a vpython execution error).`
+    );
+  } else {
+    vectorMessage(`Building environments data for workspace: ${workspaceDir}`);
+  }
 
   return jsonData;
 }


### PR DESCRIPTION
The VS-Code extension was crashing on startup for a customer. The error could be traced to accessing `.error` on an undefined object that was created as a response to a workspace environment query. 

We are now logging the exact workspace directory (one of potentially many) where the `vpython` command results in an undefined response. We now filter out undefined responses and make sure to skip them before trying to access the `.error` attribute.