### PR TITLE
Fix stuck progress label during non-advancing reqs2X phases

### DIFF
--- a/src/requirements/processRunner.ts
+++ b/src/requirements/processRunner.ts
@@ -63,7 +63,7 @@ export class ProgressTracker {
       if (increment > 0 || stepChanged) {
         this.progress.report({
           message: step,
-          increment: increment > 0 ? increment : 0,
+          increment: Math.max(increment, 0),
         });
         if (increment > 0) this.lastProgress = newProgress;
         if (step !== undefined) this.lastStep = step;

--- a/src/requirements/processRunner.ts
+++ b/src/requirements/processRunner.ts
@@ -10,6 +10,7 @@ import { spawnWithVcastEnv } from "./llmProvider";
  */
 export class ProgressTracker {
   private lastProgress = 0.0;
+  private lastStep: string | undefined;
 
   constructor(
     private progress: vscode.Progress<{ message?: string; increment?: number }>,
@@ -53,9 +54,19 @@ export class ProgressTracker {
       if (newProgress === undefined) return;
 
       const increment = (newProgress - this.lastProgress) * 100;
-      if (increment > 0) {
-        this.progress.report({ message: step, increment });
-        this.lastProgress = newProgress;
+      // Reqs2X emits a progress event at the start of each phase with the new
+      // step label but no advance (increment 0). Report on a label change too,
+      // otherwise the notification stays frozen on the previous phase's name
+      // during long, non-advancing steps (e.g. waiting for the first model
+      // response while tests are already being generated).
+      const stepChanged = step !== undefined && step !== this.lastStep;
+      if (increment > 0 || stepChanged) {
+        this.progress.report({
+          message: step,
+          increment: increment > 0 ? increment : 0,
+        });
+        if (increment > 0) this.lastProgress = newProgress;
+        if (step !== undefined) this.lastStep = step;
         logCliOperation(
           `${this.logPrefix} Progress: ${(newProgress * 100).toFixed(2)}% - ${step ?? ""}`
         );


### PR DESCRIPTION
The progress notification only updated its label when numeric progress advanced (`increment > 0`). Reqs2X emits a progress event at the start of each phase with the new step name but no advance, so the notification stayed frozen on the previous phase's label — e.g. showing "Precomputing context" for the whole "waiting for first model response" window while tests were already being generated (pronounced in batched mode, where the first test yields late).

Report on a step-label change too, clamping the bar increment to 0 for label-only updates.