### PR TITLE
Expose recent Reqs2X flags, add delta test generation, wire up the nele provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -509,12 +509,6 @@
             "default": true,
             "description": "Generate tests in batches (multiple requirements per LLM call). Disable for one-request-per-requirement (slower, simpler retries)."
           },
-          "vectorcastTestExplorer.reqs2x.reorder": {
-            "type": "boolean",
-            "order": 8,
-            "default": true,
-            "description": "Reorder test cases exported to file (disable for easier investigation of incremental results)"
-          },
           "vectorcastTestExplorer.reqs2x.noTestExamples": {
             "type": "boolean",
             "order": 9,
@@ -561,8 +555,8 @@
             "type": "string",
             "order": 15,
             "default": "openai",
-            "enum": ["openai", "azure_openai", "anthropic", "litellm", "azure_apim", "openai_at"],
-            "enumDescriptions": ["OpenAI", "Azure OpenAI", "Anthropic", "LiteLLM", "Azure APIM (Advanced)", "OpenAI Access Token (Advanced)"],
+            "enum": ["openai", "azure_openai", "anthropic", "litellm", "nele", "azure_apim", "openai_at"],
+            "enumDescriptions": ["OpenAI", "Azure OpenAI", "Anthropic", "LiteLLM", "nele.ai", "Azure APIM (Advanced)", "OpenAI Access Token (Advanced)"],
             "description": "Language model provider for automatic requirements and test generation using Reqs2X"
           },
           "vectorcastTestExplorer.reqs2x.openai.apiKey": {
@@ -667,75 +661,99 @@
             "default": "",
             "description": "Environment variables to set when running LiteLLM, e.g., OPENAI_API_KEY=xxxx. Multiple variables can be separated by commas, e.g., OPENAI_API_KEY=xxxx,ANOTHER_ENV_VAR=yyyy. For a list of variables to set for a specific LiteLLM-compatible provider, see https://docs.litellm.ai/docs/providers."
           },
-          "vectorcastTestExplorer.reqs2x.azureApim.subscriptionKey": {
+          "vectorcastTestExplorer.reqs2x.nele.apiKey": {
             "type": "string",
             "order": 33,
+            "default": "",
+            "description": "nele.ai API key (sent as a bearer token)"
+          },
+          "vectorcastTestExplorer.reqs2x.nele.baseUrl": {
+            "type": "string",
+            "order": 34,
+            "default": "",
+            "description": "nele.ai gateway base URL, e.g., https://api.aieva.io/api/v1"
+          },
+          "vectorcastTestExplorer.reqs2x.nele.modelName": {
+            "type": "string",
+            "order": 35,
+            "default": "",
+            "description": "nele.ai model name, e.g., azure-gpt-4.1"
+          },
+          "vectorcastTestExplorer.reqs2x.nele.reasoningModelName": {
+            "type": "string",
+            "order": 36,
+            "default": "",
+            "description": "Optional nele.ai reasoning model name used for specialized reasoning subtasks."
+          },
+          "vectorcastTestExplorer.reqs2x.azureApim.subscriptionKey": {
+            "type": "string",
+            "order": 37,
             "default": "",
             "description": "[Advanced] Azure APIM subscription key (sent as the Ocp-Apim-Subscription-Key header)"
           },
           "vectorcastTestExplorer.reqs2x.azureApim.baseUrl": {
             "type": "string",
-            "order": 34,
+            "order": 38,
             "default": "",
             "description": "[Advanced] Azure APIM gateway base URL, e.g., https://some-domain.azure-api.net/v1"
           },
           "vectorcastTestExplorer.reqs2x.azureApim.modelName": {
             "type": "string",
-            "order": 35,
+            "order": 39,
             "default": "",
             "description": "[Advanced] Model name for the APIM-proxied LLM, e.g., gpt-4.1"
           },
           "vectorcastTestExplorer.reqs2x.azureApim.apiKey": {
             "type": "string",
-            "order": 36,
+            "order": 40,
             "default": "",
             "description": "[Advanced] Optional downstream Azure OpenAI API key (forwarded when the APIM policy requires it)"
           },
           "vectorcastTestExplorer.reqs2x.azureApim.reasoningModelName": {
             "type": "string",
-            "order": 37,
+            "order": 41,
             "default": "",
             "description": "[Advanced] Optional reasoning model name used for specialized reasoning subtasks (Azure APIM)."
           },
           "vectorcastTestExplorer.reqs2x.openaiAt.modelName": {
             "type": "string",
-            "order": 38,
+            "order": 42,
             "default": "",
             "description": "[Advanced] OpenAI Access Token model name"
           },
           "vectorcastTestExplorer.reqs2x.openaiAt.modelUrl": {
             "type": "string",
-            "order": 39,
+            "order": 43,
             "default": "",
             "description": "[Advanced] OpenAI Access Token model URL"
           },
           "vectorcastTestExplorer.reqs2x.openaiAt.authUrl": {
             "type": "string",
-            "order": 40,
+            "order": 44,
             "default": "",
             "description": "[Advanced] OpenAI Access Token authentication URL"
           },
           "vectorcastTestExplorer.reqs2x.openaiAt.appKey": {
             "type": "string",
-            "order": 41,
+            "order": 45,
             "default": "",
             "description": "[Advanced] OpenAI Access Token application key"
           },
           "vectorcastTestExplorer.reqs2x.openaiAt.appSecret": {
             "type": "string",
-            "order": 42,
+            "order": 46,
             "default": "",
             "description": "[Advanced] OpenAI Access Token application secret"
           },
           "vectorcastTestExplorer.reqs2x.openaiAt.reasoningModelName": {
             "type": "string",
-            "order": 43,
+            "order": 47,
             "default": "",
             "description": "[Advanced] Optional reasoning model name used for specialized reasoning subtasks (OpenAI Access Token)."
           },
           "vectorcastTestExplorer.reqs2x.extraModelParamsTemplate": {
             "type": "string",
-            "order": 44,
+            "order": 48,
             "default": "",
             "enum": ["", "vllm-thinking-off", "gemini-reasoning-minimal", "gpt5-reasoning-minimal"],
             "enumDescriptions": [
@@ -748,14 +766,14 @@
           },
           "vectorcastTestExplorer.reqs2x.extraModelParamsJson": {
             "type": "string",
-            "order": 45,
+            "order": 49,
             "default": "",
             "editPresentation": "multilineText",
             "description": "[Advanced] Custom JSON blob deep-merged on top of the template (or used standalone), e.g., {\"temperature\": 0.6, \"max_tokens\": 16000}. Passed straight to the SDK — invalid keys fail at request time."
           },
           "vectorcastTestExplorer.reqs2x.reasoningExtraModelParamsTemplate": {
             "type": "string",
-            "order": 46,
+            "order": 50,
             "default": "",
             "enum": ["", "vllm-thinking-off", "gemini-reasoning-minimal", "gpt5-reasoning-minimal"],
             "enumDescriptions": [
@@ -768,7 +786,7 @@
           },
           "vectorcastTestExplorer.reqs2x.reasoningExtraModelParamsJson": {
             "type": "string",
-            "order": 47,
+            "order": 51,
             "default": "",
             "editPresentation": "multilineText",
             "description": "[Advanced] Custom JSON for the reasoning role. Same semantics as extraModelParamsJson."

--- a/package.json
+++ b/package.json
@@ -316,6 +316,12 @@
         "enablement": "testId in vectorcastTestExplorer.vcastRequirementsAvailable"
       },
       {
+        "command": "vectorcastTestExplorer.generateTestsFromRequirementsDelta",
+        "category": "VectorCAST Test Explorer",
+        "title": "Generate Tests from Requirements (Untested or Changed Only)",
+        "enablement": "testId in vectorcastTestExplorer.vcastRequirementsAvailable"
+      },
+      {
         "command": "vectorcastTestExplorer.viewMCDCReport",
         "category": "VectorCAST Test Explorer",
         "title": "VectorCAST MC/DC Report"
@@ -509,27 +515,69 @@
             "default": true,
             "description": "Generate tests in batches (multiple requirements per LLM call). Disable for one-request-per-requirement (slower, simpler retries)."
           },
-          "vectorcastTestExplorer.reqs2x.noTestExamples": {
+          "vectorcastTestExplorer.reqs2x.batchSize": {
+            "type": "integer",
+            "order": 8,
+            "default": 4,
+            "minimum": 1,
+            "description": "Maximum number of requirements per batch when batched generation is enabled. Larger batches are cheaper but give the model less room per requirement."
+          },
+          "vectorcastTestExplorer.reqs2x.fastMode": {
             "type": "boolean",
             "order": 9,
             "default": false,
+            "description": "Skip test execution and example generation for much faster runs. Generated tests are not run or error-corrected, so quality may be slightly lower (syntax is still enforced). Overrides the test example and partial test settings."
+          },
+          "vectorcastTestExplorer.reqs2x.deduplicateTests": {
+            "type": "boolean",
+            "order": 10,
+            "default": true,
+            "description": "Remove generated tests that verify the same behaviour as another generated test."
+          },
+          "vectorcastTestExplorer.reqs2x.allowPartialTests": {
+            "type": "boolean",
+            "order": 11,
+            "default": true,
+            "description": "Keep tests that only partially verify their requirement, marked as PARTIAL. Disable to discard them instead. Has no effect in fast mode, which cannot detect partial tests."
+          },
+          "vectorcastTestExplorer.reqs2x.maxTestExamples": {
+            "type": "integer",
+            "order": 12,
+            "default": 3,
+            "minimum": 0,
+            "description": "Maximum number of example test cases to include in the LLM context during test generation. Set to 0 to provide no examples."
+          },
+          "vectorcastTestExplorer.reqs2x.testExampleSources": {
+            "type": "array",
+            "order": 13,
+            "default": ["environment", "generated"],
+            "items": {
+              "type": "string"
+            },
+            "markdownDescription": "Where example test cases come from, in priority order. Each entry is either `environment` (tests already loaded in the environment), `generated` (ATG/basis-path tests), or a path to a VectorCAST `.tst` file. Ignored when `#vectorcastTestExplorer.reqs2x.maxTestExamples#` is 0."
+          },
+          "vectorcastTestExplorer.reqs2x.noTestExamples": {
+            "type": "boolean",
+            "order": 14,
+            "default": false,
+            "markdownDeprecationMessage": "Deprecated: set `#vectorcastTestExplorer.reqs2x.maxTestExamples#` to 0 instead. While this is enabled it still overrides that setting.",
             "description": "Do not provide additional test examples to the LLM during test generation"
           },
           "vectorcastTestExplorer.reqs2x.functionDefinitions": {
             "type": "boolean",
-            "order": 10,
+            "order": 15,
             "default": true,
             "description": "Supply function definitions to the language model during test generation. Disable for blackbox-style testing."
           },
           "vectorcastTestExplorer.reqs2x.enableUutStubbing": {
             "type": "boolean",
-            "order": 11,
+            "order": 16,
             "default": true,
             "description": "Enable UUT stubbing during requirements-based test generation"
           },
           "vectorcastTestExplorer.reqs2x.generationLanguage": {
             "type": "string",
-            "order": 12,
+            "order": 17,
             "default": "en",
             "enum": [
               "af", "sq", "am", "ar", "hy", "as", "az", "be", "bn", "bs", "bg", "my", "ch", "hr", "cs", "da", "nl", "en", "et", "tl", "fi", "fr", "ka", "de", "gu", "ha", "he", "hi", "hu", "is", "ig", "id", "ga", "it", "jp", "kn", "kk", "km", "ko", "ky", "lo", "lv", "lt", "mk", "ms", "ml", "mt", "mn", "me", "ne", "no", "or", "fa", "pl", "pt", "pa", "ro", "ru", "sr", "si", "sk", "sl", "es", "sw", "sv", "tg", "ta", "te", "th", "tr", "uk", "ur", "uz", "vi", "cy", "xh", "yo", "zu"
@@ -541,19 +589,19 @@
           },
           "vectorcastTestExplorer.reqs2x.sourceFileEncoding": {
             "type": "string",
-            "order": 13,
+            "order": 18,
             "default": "",
             "description": "Encoding used by Reqs2X to read source files and existing test scripts (e.g., cp1252, gbk). If empty, Reqs2X tries UTF-8 first and falls back to automatic charset detection."
           },
           "vectorcastTestExplorer.reqs2x.modelCompatibilityMode": {
             "type": "boolean",
-            "order": 14,
+            "order": 19,
             "default": false,
             "description": "Enable model compatibility mode (runs Reqs2X tools without structured outputs which enables compatibility with more providers)."
           },
           "vectorcastTestExplorer.reqs2x.provider": {
             "type": "string",
-            "order": 15,
+            "order": 20,
             "default": "openai",
             "enum": ["openai", "azure_openai", "anthropic", "litellm", "nele", "azure_apim", "openai_at"],
             "enumDescriptions": ["OpenAI", "Azure OpenAI", "Anthropic", "LiteLLM", "nele.ai", "Azure APIM (Advanced)", "OpenAI Access Token (Advanced)"],
@@ -561,199 +609,199 @@
           },
           "vectorcastTestExplorer.reqs2x.openai.apiKey": {
             "type": "string",
-            "order": 16,
+            "order": 21,
             "default": "",
             "description": "OpenAI API key"
           },
           "vectorcastTestExplorer.reqs2x.openai.modelName": {
             "type": "string",
-            "order": 17,
+            "order": 22,
             "default": "",
             "description": "OpenAI model name"
           },
           "vectorcastTestExplorer.reqs2x.openai.reasoningModelName": {
             "type": "string",
-            "order": 18,
+            "order": 23,
             "default": "",
             "description": "Optional OpenAI reasoning model name used for specialized reasoning subtasks."
           },
           "vectorcastTestExplorer.reqs2x.openai.baseUrl": {
             "type": "string",
-            "order": 19,
+            "order": 24,
             "default": "",
             "description": "OpenAI base URL (optional, set this to use OpenAI-compatible providers such as Ollama, vLLM or Bedrock)"
           },
           "vectorcastTestExplorer.reqs2x.azure.baseUrl": {
             "type": "string",
-            "order": 20,
+            "order": 25,
             "default": "",
             "description": "Azure OpenAI endpoint/base URL, e.g., https://my-example-instance.openai.azure.com"
           },
           "vectorcastTestExplorer.reqs2x.azure.apiKey": {
             "type": "string",
-            "order": 21,
+            "order": 26,
             "default": "",
             "description": "Azure OpenAI API key"
           },
           "vectorcastTestExplorer.reqs2x.azure.deployment": {
             "type": "string",
-            "order": 22,
+            "order": 27,
             "default": "",
             "description": "Azure OpenAI deployment name, e.g., my-custom-gpt-4o-deployment"
           },
           "vectorcastTestExplorer.reqs2x.azure.modelName": {
             "type": "string",
-            "order": 23,
+            "order": 28,
             "default": "",
             "description": "Azure OpenAI model name, e.g., gpt-4o"
           },
           "vectorcastTestExplorer.reqs2x.azure.reasoningModelName": {
             "type": "string",
-            "order": 24,
+            "order": 29,
             "default": "",
             "description": "Optional Azure OpenAI reasoning model name used for specialized reasoning subtasks."
           },
           "vectorcastTestExplorer.reqs2x.azure.reasoningDeployment": {
             "type": "string",
-            "order": 25,
+            "order": 30,
             "default": "",
             "description": "Azure OpenAI reasoning deployment name (required if Azure reasoning model name is provided)."
           },
           "vectorcastTestExplorer.reqs2x.azure.apiVersion": {
             "type": "string",
-            "order": 26,
+            "order": 31,
             "default": "2024-12-01-preview",
             "description": "Azure OpenAI API version"
           },
           "vectorcastTestExplorer.reqs2x.anthropic.apiKey": {
             "type": "string",
-            "order": 27,
+            "order": 32,
             "default": "",
             "description": "Anthropic API key"
           },
           "vectorcastTestExplorer.reqs2x.anthropic.modelName": {
             "type": "string",
-            "order": 28,
+            "order": 33,
             "default": "",
             "description": "Anthropic model name"
           },
           "vectorcastTestExplorer.reqs2x.anthropic.reasoningModelName": {
             "type": "string",
-            "order": 29,
+            "order": 34,
             "default": "",
             "description": "Optional Anthropic reasoning model name used for specialized reasoning subtasks."
           },
           "vectorcastTestExplorer.reqs2x.litellm.modelName": {
             "type": "string",
-            "order": 30,
+            "order": 35,
             "default": "",
             "description": "LiteLLM model name (prefix with provider used, e.g., openai/gpt-4o or azure/o3-mini)"
           },
           "vectorcastTestExplorer.reqs2x.litellm.reasoningModelName": {
             "type": "string",
-            "order": 31,
+            "order": 36,
             "default": "",
             "description": "Optional LiteLLM reasoning model name used for specialized reasoning subtasks."
           },
           "vectorcastTestExplorer.reqs2x.litellm.providerEnvVars": {
             "type": "string",
-            "order": 32,
+            "order": 37,
             "default": "",
             "description": "Environment variables to set when running LiteLLM, e.g., OPENAI_API_KEY=xxxx. Multiple variables can be separated by commas, e.g., OPENAI_API_KEY=xxxx,ANOTHER_ENV_VAR=yyyy. For a list of variables to set for a specific LiteLLM-compatible provider, see https://docs.litellm.ai/docs/providers."
           },
           "vectorcastTestExplorer.reqs2x.nele.apiKey": {
             "type": "string",
-            "order": 33,
+            "order": 38,
             "default": "",
             "description": "nele.ai API key (sent as a bearer token)"
           },
           "vectorcastTestExplorer.reqs2x.nele.baseUrl": {
             "type": "string",
-            "order": 34,
+            "order": 39,
             "default": "",
             "description": "nele.ai gateway base URL, e.g., https://api.aieva.io/api/v1"
           },
           "vectorcastTestExplorer.reqs2x.nele.modelName": {
             "type": "string",
-            "order": 35,
+            "order": 40,
             "default": "",
             "description": "nele.ai model name, e.g., azure-gpt-4.1"
           },
           "vectorcastTestExplorer.reqs2x.nele.reasoningModelName": {
             "type": "string",
-            "order": 36,
+            "order": 41,
             "default": "",
             "description": "Optional nele.ai reasoning model name used for specialized reasoning subtasks."
           },
           "vectorcastTestExplorer.reqs2x.azureApim.subscriptionKey": {
             "type": "string",
-            "order": 37,
+            "order": 42,
             "default": "",
             "description": "[Advanced] Azure APIM subscription key (sent as the Ocp-Apim-Subscription-Key header)"
           },
           "vectorcastTestExplorer.reqs2x.azureApim.baseUrl": {
             "type": "string",
-            "order": 38,
+            "order": 43,
             "default": "",
             "description": "[Advanced] Azure APIM gateway base URL, e.g., https://some-domain.azure-api.net/v1"
           },
           "vectorcastTestExplorer.reqs2x.azureApim.modelName": {
             "type": "string",
-            "order": 39,
+            "order": 44,
             "default": "",
             "description": "[Advanced] Model name for the APIM-proxied LLM, e.g., gpt-4.1"
           },
           "vectorcastTestExplorer.reqs2x.azureApim.apiKey": {
             "type": "string",
-            "order": 40,
+            "order": 45,
             "default": "",
             "description": "[Advanced] Optional downstream Azure OpenAI API key (forwarded when the APIM policy requires it)"
           },
           "vectorcastTestExplorer.reqs2x.azureApim.reasoningModelName": {
             "type": "string",
-            "order": 41,
+            "order": 46,
             "default": "",
             "description": "[Advanced] Optional reasoning model name used for specialized reasoning subtasks (Azure APIM)."
           },
           "vectorcastTestExplorer.reqs2x.openaiAt.modelName": {
             "type": "string",
-            "order": 42,
+            "order": 47,
             "default": "",
             "description": "[Advanced] OpenAI Access Token model name"
           },
           "vectorcastTestExplorer.reqs2x.openaiAt.modelUrl": {
             "type": "string",
-            "order": 43,
+            "order": 48,
             "default": "",
             "description": "[Advanced] OpenAI Access Token model URL"
           },
           "vectorcastTestExplorer.reqs2x.openaiAt.authUrl": {
             "type": "string",
-            "order": 44,
+            "order": 49,
             "default": "",
             "description": "[Advanced] OpenAI Access Token authentication URL"
           },
           "vectorcastTestExplorer.reqs2x.openaiAt.appKey": {
             "type": "string",
-            "order": 45,
+            "order": 50,
             "default": "",
             "description": "[Advanced] OpenAI Access Token application key"
           },
           "vectorcastTestExplorer.reqs2x.openaiAt.appSecret": {
             "type": "string",
-            "order": 46,
+            "order": 51,
             "default": "",
             "description": "[Advanced] OpenAI Access Token application secret"
           },
           "vectorcastTestExplorer.reqs2x.openaiAt.reasoningModelName": {
             "type": "string",
-            "order": 47,
+            "order": 52,
             "default": "",
             "description": "[Advanced] Optional reasoning model name used for specialized reasoning subtasks (OpenAI Access Token)."
           },
           "vectorcastTestExplorer.reqs2x.extraModelParamsTemplate": {
             "type": "string",
-            "order": 48,
+            "order": 53,
             "default": "",
             "enum": ["", "vllm-thinking-off", "gemini-reasoning-minimal", "gpt5-reasoning-minimal"],
             "enumDescriptions": [
@@ -766,14 +814,14 @@
           },
           "vectorcastTestExplorer.reqs2x.extraModelParamsJson": {
             "type": "string",
-            "order": 49,
+            "order": 54,
             "default": "",
             "editPresentation": "multilineText",
             "description": "[Advanced] Custom JSON blob deep-merged on top of the template (or used standalone), e.g., {\"temperature\": 0.6, \"max_tokens\": 16000}. Passed straight to the SDK — invalid keys fail at request time."
           },
           "vectorcastTestExplorer.reqs2x.reasoningExtraModelParamsTemplate": {
             "type": "string",
-            "order": 50,
+            "order": 55,
             "default": "",
             "enum": ["", "vllm-thinking-off", "gemini-reasoning-minimal", "gpt5-reasoning-minimal"],
             "enumDescriptions": [
@@ -786,7 +834,7 @@
           },
           "vectorcastTestExplorer.reqs2x.reasoningExtraModelParamsJson": {
             "type": "string",
-            "order": 51,
+            "order": 56,
             "default": "",
             "editPresentation": "multilineText",
             "description": "[Advanced] Custom JSON for the reasoning role. Same semantics as extraModelParamsJson."
@@ -959,6 +1007,10 @@
         },
         {
           "command": "vectorcastTestExplorer.generateTestsFromRequirements",
+          "when": "never"
+        },
+        {
+          "command": "vectorcastTestExplorer.generateTestsFromRequirementsDelta",
           "when": "never"
         },
         {
@@ -1316,6 +1368,11 @@
         "command": "vectorcastTestExplorer.generateTestsFromRequirements",
         "group": "vcast@10",
         "when": "testId =~ /^vcast:.*$/ && vectorcastTestExplorer.reqs2xFeatureEnabled && testId not in vectorcastTestExplorer.vcastLegacyMigrationAvailable"
+      },
+      {
+        "command": "vectorcastTestExplorer.generateTestsFromRequirementsDelta",
+        "group": "vcast@11",
+        "when": "testId =~ /^vcast:.*$/ && vectorcastTestExplorer.reqs2xFeatureEnabled && vectorcastTestExplorer.reqs2xSupportsDelta && testId not in vectorcastTestExplorer.vcastLegacyMigrationAvailable"
       },
       {
         "command": "vectorcastTestExplorer.removeRequirements",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -674,6 +674,22 @@ function configureExtension(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(generateRequirementsTestsCommand);
 
+  let generateRequirementsTestsDeltaCommand = vscode.commands.registerCommand(
+    "vectorcastTestExplorer.generateTestsFromRequirementsDelta",
+    async (args: any) => {
+      if (args) {
+        const testNode: testNodeType = getTestNode(args.id);
+        const enviroPath = testNode.enviroPath;
+        await generateTestsFromRequirements(
+          enviroPath,
+          testNode.functionName || testNode.unitName || null,
+          { onlyDelta: true }
+        );
+      }
+    }
+  );
+  context.subscriptions.push(generateRequirementsTestsDeltaCommand);
+
   let importRequirementsCommand = vscode.commands.registerCommand(
     "vectorcastTestExplorer.importRequirements",
     async (args: any) => {

--- a/src/requirements/availability.ts
+++ b/src/requirements/availability.ts
@@ -3,7 +3,6 @@ import { normalizePath } from "../utilities";
 import { makeEnviroNodeID } from "../testPane";
 import { testNodeCache } from "../testData";
 import { hasCompleteAndUsableRGW } from "./rgwIo";
-import { logCliOperation } from "./requirementsLog";
 
 const path = require("path");
 
@@ -76,13 +75,8 @@ export function updateRequirementsAvailability(enviroPath: string) {
  * etc.) don't tell us which env was affected, and the eval is cheap enough
  * (a few `fs.existsSync` per env) to just do everything.
  */
-async function refreshAllRequirementsAvailability(
-  reason: string
-): Promise<void> {
+async function refreshAllRequirementsAvailability(): Promise<void> {
   const envFiles = await vscode.workspace.findFiles("**/*.env");
-  logCliOperation(
-    `availability: refresh (${reason}); ${envFiles.length} env(s) found`
-  );
   for (const uri of envFiles) {
     const envDir = path.dirname(uri.fsPath);
     const envName = path.basename(uri.fsPath, ".env");
@@ -107,21 +101,21 @@ async function refreshAllRequirementsAvailability(
 export function setupRequirementsFileWatchers(
   context: vscode.ExtensionContext
 ): void {
-  const refresh = (reason: string) => () => {
-    void refreshAllRequirementsAvailability(reason);
+  const refresh = () => {
+    void refreshAllRequirementsAvailability();
   };
 
   const rgwWatcher = vscode.workspace.createFileSystemWatcher(
     "**/requirements_gateway/requirements.json"
   );
-  rgwWatcher.onDidCreate(refresh("rgw create"), null, context.subscriptions);
-  rgwWatcher.onDidDelete(refresh("rgw delete"), null, context.subscriptions);
+  rgwWatcher.onDidCreate(refresh, null, context.subscriptions);
+  rgwWatcher.onDidDelete(refresh, null, context.subscriptions);
   context.subscriptions.push(rgwWatcher);
 
   const cfgWatcher = vscode.workspace.createFileSystemWatcher("**/CCAST_.CFG");
-  cfgWatcher.onDidChange(refresh("ccast change"), null, context.subscriptions);
-  cfgWatcher.onDidCreate(refresh("ccast create"), null, context.subscriptions);
-  cfgWatcher.onDidDelete(refresh("ccast delete"), null, context.subscriptions);
+  cfgWatcher.onDidChange(refresh, null, context.subscriptions);
+  cfgWatcher.onDidCreate(refresh, null, context.subscriptions);
+  cfgWatcher.onDidDelete(refresh, null, context.subscriptions);
   context.subscriptions.push(cfgWatcher);
 
   // Fallback: VS Code regains focus. Cheap and catches the bulk-delete case
@@ -129,7 +123,7 @@ export function setupRequirementsFileWatchers(
   context.subscriptions.push(
     vscode.window.onDidChangeWindowState((state) => {
       if (state.focused) {
-        void refreshAllRequirementsAvailability("window focused");
+        void refreshAllRequirementsAvailability();
       }
     })
   );

--- a/src/requirements/llmProvider.ts
+++ b/src/requirements/llmProvider.ts
@@ -111,6 +111,26 @@ export function gatherLLMProviderSettings(): LLMProviderSettingsResult {
       config.get<string>("reqs2x.anthropic.reasoningModelName"),
       "VCAST_REQS2X_REASONING_ANTHROPIC_MODEL_NAME"
     );
+  } else if (provider === "nele") {
+    need(
+      config.get<string>("reqs2x.nele.apiKey"),
+      "nele.ai API Key",
+      "VCAST_REQS2X_NELE_API_KEY"
+    );
+    need(
+      config.get<string>("reqs2x.nele.baseUrl"),
+      "nele.ai Base URL",
+      "VCAST_REQS2X_NELE_BASE_URL"
+    );
+    need(
+      config.get<string>("reqs2x.nele.modelName"),
+      "nele.ai Model Name",
+      "VCAST_REQS2X_NELE_MODEL_NAME"
+    );
+    optional(
+      config.get<string>("reqs2x.nele.reasoningModelName"),
+      "VCAST_REQS2X_REASONING_NELE_MODEL_NAME"
+    );
   } else if (provider === "litellm") {
     need(
       config.get<string>("reqs2x.litellm.modelName"),

--- a/src/requirements/processRunner.ts
+++ b/src/requirements/processRunner.ts
@@ -69,6 +69,21 @@ export class ProgressTracker {
       }
       vscode.window.showWarningMessage(json.value);
       logCliOperation(`Warning: ${json.value}`);
+    } else if (json.event === "info") {
+      // User-facing status the tool wants surfaced even though nothing went
+      // wrong — e.g. "nothing to infer / nothing to do" on the --only-untraced
+      // and --only-delta paths, where the run otherwise completes with no
+      // visible effect.
+      vscode.window.showInformationMessage(json.value);
+      logCliOperation(`${this.logPrefix}: ${json.value}`);
+    } else if (json.event === "notice") {
+      // Vector Subscription nudge: `{ phase, text }`. Phase 1 is informational;
+      // later phases escalate to a warning, mirroring how the CLI renders it.
+      const { phase, text } = json.value;
+      if (!text) return;
+      if (phase >= 2) vscode.window.showWarningMessage(text);
+      else vscode.window.showInformationMessage(text);
+      logCliOperation(`${this.logPrefix} notice (phase ${phase}): ${text}`);
     }
   }
 }

--- a/src/requirements/requirementsExecutables.ts
+++ b/src/requirements/requirementsExecutables.ts
@@ -141,10 +141,7 @@ function reqs2xHelpText(exe: string): Promise<string> {
  * `false` when unknown, so callers degrade instead of passing something the
  * binary rejects.
  */
-async function reqs2xSupportsFlag(
-  exe: string,
-  flag: string
-): Promise<boolean> {
+async function reqs2xSupportsFlag(exe: string, flag: string): Promise<boolean> {
   if (!exe) return false;
   return (await reqs2xHelpText(exe)).includes(flag);
 }

--- a/src/requirements/requirementsExecutables.ts
+++ b/src/requirements/requirementsExecutables.ts
@@ -151,7 +151,8 @@ async function reqs2xSupportsFlag(
 
 /**
  * Filter `flags` down to those the binary accepts. One probe covers all of
- * them, since the help output is cached per binary.
+ * them, since the help output is cached per binary. Reporting what is missing is
+ * left to callers, which know whether the user actually asked for it.
  */
 export async function reqs2xSupportedFlags(
   exe: string,
@@ -159,14 +160,7 @@ export async function reqs2xSupportedFlags(
 ): Promise<Set<string>> {
   if (!exe) return new Set();
   const help = await reqs2xHelpText(exe);
-  const supported = new Set(flags.filter((flag) => help.includes(flag)));
-  const missing = flags.filter((flag) => !supported.has(flag));
-  if (missing.length > 0) {
-    logCliOperation(
-      `reqs2x: ${exe} does not support ${missing.join(", ")}; omitting`
-    );
-  }
-  return supported;
+  return new Set(flags.filter((flag) => help.includes(flag)));
 }
 
 // Recent enough that the installed Reqs2X may not have them, so they get probed

--- a/src/requirements/requirementsExecutables.ts
+++ b/src/requirements/requirementsExecutables.ts
@@ -99,49 +99,89 @@ export function setupReqs2XExecutablePaths(
     exeFilename("llm2check")
   ).fsPath;
 
-  // A different binary may have been resolved; drop the cached probe.
-  onlyUntracedSupport = undefined;
+  // A different binary may have been resolved; drop the cached help output.
+  helpTextCache.clear();
 
   return true;
 }
 
-let onlyUntracedSupport: boolean | undefined; // undefined until first probed
-let onlyUntracedProbe: Promise<boolean> | undefined;
+// Resolved exe path -> its `--help` output. The promise itself is cached so
+// concurrent callers share one subprocess, and a failed probe stays cached as
+// empty rather than re-running (and re-waiting out the timeout) every call.
+const helpTextCache = new Map<string, Promise<string>>();
 
-/**
- * Probe (once, cached) whether the resolved `panreq` supports `--only-untraced`
- * by scanning `panreq --help`. `panreq` ships with VectorCAST and is versioned
- * independently of this extension, so an older one may predate the flag. Any
- * failure resolves to `false` — callers then fall back to full inference rather
- * than passing a flag the binary would reject.
- */
-export async function panreqSupportsOnlyUntraced(): Promise<boolean> {
-  if (onlyUntracedSupport !== undefined) return onlyUntracedSupport;
-  if (onlyUntracedProbe) return onlyUntracedProbe;
-  if (!PANREQ_EXECUTABLE_PATH) return false;
+function reqs2xHelpText(exe: string): Promise<string> {
+  const cached = helpTextCache.get(exe);
+  if (cached) return cached;
 
-  onlyUntracedProbe = (async () => {
-    let supported = false;
+  const probe = (async () => {
     try {
       const result = await runReqs2xTool({
-        exe: PANREQ_EXECUTABLE_PATH,
+        exe,
         args: ["--help"],
         captureOutput: true,
         allowNonZeroExit: true,
         timeoutMs: 10000,
       });
-      const help = `${result.stdout ?? ""}${result.stderr ?? ""}`;
-      supported = help.includes("--only-untraced");
+      return `${result.stdout ?? ""}${result.stderr ?? ""}`;
     } catch (err) {
-      logCliError(`panreq capability probe failed: ${err}`);
+      logCliError(`reqs2x capability probe failed for ${exe}: ${err}`);
+      return "";
     }
-    onlyUntracedSupport = supported;
-    onlyUntracedProbe = undefined;
-    logCliOperation(
-      `panreq --only-untraced support: ${supported ? "yes" : "no"}`
-    );
-    return supported;
   })();
 
-  return onlyUntracedProbe;
+  helpTextCache.set(exe, probe);
+  return probe;
+}
+
+/**
+ * Whether the resolved binary accepts `flag`, per its `--help`. The Reqs2X tools
+ * ship with VectorCAST and are versioned independently of this extension, so an
+ * older installation may predate a flag we would otherwise pass. Resolves to
+ * `false` when unknown, so callers degrade instead of passing something the
+ * binary rejects.
+ */
+async function reqs2xSupportsFlag(
+  exe: string,
+  flag: string
+): Promise<boolean> {
+  if (!exe) return false;
+  return (await reqs2xHelpText(exe)).includes(flag);
+}
+
+/**
+ * Filter `flags` down to those the binary accepts. One probe covers all of
+ * them, since the help output is cached per binary.
+ */
+export async function reqs2xSupportedFlags(
+  exe: string,
+  flags: string[]
+): Promise<Set<string>> {
+  if (!exe) return new Set();
+  const help = await reqs2xHelpText(exe);
+  const supported = new Set(flags.filter((flag) => help.includes(flag)));
+  const missing = flags.filter((flag) => !supported.has(flag));
+  if (missing.length > 0) {
+    logCliOperation(
+      `reqs2x: ${exe} does not support ${missing.join(", ")}; omitting`
+    );
+  }
+  return supported;
+}
+
+// Recent enough that the installed Reqs2X may not have them, so they get probed
+// before use.
+export const RECENT_REQS2TESTS_FLAGS = [
+  "--fast",
+  "--max-test-examples",
+  "--test-examples-sources",
+];
+
+export async function panreqSupportsOnlyUntraced(): Promise<boolean> {
+  return reqs2xSupportsFlag(PANREQ_EXECUTABLE_PATH, "--only-untraced");
+}
+
+// Also recent; probed separately because it gates a command, not an argument.
+export async function reqs2testsSupportsDelta(): Promise<boolean> {
+  return reqs2xSupportsFlag(REQS2TESTS_EXECUTABLE_PATH, "--only-delta");
 }

--- a/src/requirements/requirementsOperations.ts
+++ b/src/requirements/requirementsOperations.ts
@@ -148,6 +148,11 @@ export async function generateRequirements(enviroPath: string) {
   }
 }
 
+// Mirror of the defaults declared in package.json. Needed beyond config.get's
+// fallback so we can tell an untouched setting from one the user chose.
+const DEFAULT_MAX_TEST_EXAMPLES = 3;
+const DEFAULT_TEST_EXAMPLE_SOURCES = ["environment", "generated"];
+
 export async function generateTestsFromRequirements(
   enviroPath: string,
   unitOrFunctionName: string | null,
@@ -194,17 +199,20 @@ export async function generateTestsFromRequirements(
   const fastMode = config.get<boolean>("fastMode", false);
   const deduplicate = config.get<boolean>("deduplicateTests", true);
   const allowPartial = config.get<boolean>("allowPartialTests", true);
-  const exampleSources = config.get<string[]>("testExampleSources", [
-    "environment",
-    "generated",
-  ]);
+  const exampleSources = config.get<string[]>(
+    "testExampleSources",
+    DEFAULT_TEST_EXAMPLE_SOURCES
+  );
 
   // Clamped because settings.json can be hand-edited past the schema minimum.
   // Deprecated noTestExamples still wins while explicitly enabled.
   const batchSize = Math.max(1, config.get<number>("batchSize", 4));
   const maxTestExamples = config.get<boolean>("noTestExamples", false)
     ? 0
-    : Math.max(0, config.get<number>("maxTestExamples", 3));
+    : Math.max(
+        0,
+        config.get<number>("maxTestExamples", DEFAULT_MAX_TEST_EXAMPLES)
+      );
 
   const retries = config.get<number>("retries", 2);
   if (retries < 1) {
@@ -220,6 +228,35 @@ export async function generateTestsFromRequirements(
     REQS2TESTS_EXECUTABLE_PATH,
     RECENT_REQS2TESTS_FLAGS
   );
+
+  // Settings whose flag this Reqs2X lacks are dropped rather than passed, which
+  // would fail the run. Only mention the ones actually asked for: on an
+  // untouched default nothing is lost, because the CLI default matches.
+  const ignored: string[] = [];
+  if (fastMode && !supported.has("--fast")) {
+    ignored.push("fast mode");
+  }
+  if (maxTestExamples > 0) {
+    if (
+      maxTestExamples !== DEFAULT_MAX_TEST_EXAMPLES &&
+      !supported.has("--max-test-examples")
+    ) {
+      ignored.push("maximum test examples");
+    }
+    const sourcesMatchDefault =
+      exampleSources.length === DEFAULT_TEST_EXAMPLE_SOURCES.length &&
+      exampleSources.every((s, i) => s === DEFAULT_TEST_EXAMPLE_SOURCES[i]);
+    // An empty list is never passed either way, so it is not "ignored".
+    const customSources = exampleSources.length > 0 && !sourcesMatchDefault;
+    if (customSources && !supported.has("--test-examples-sources")) {
+      ignored.push("test example sources");
+    }
+  }
+  if (ignored.length > 0) {
+    const message = `The installed Reqs2X does not support these settings, which were ignored: ${ignored.join(", ")}.`;
+    vscode.window.showWarningMessage(message);
+    logCliOperation(`reqs2tests: ${message}`);
+  }
 
   const exampleArgs: string[] = [];
   if (maxTestExamples === 0) {

--- a/src/requirements/requirementsOperations.ts
+++ b/src/requirements/requirementsOperations.ts
@@ -95,8 +95,6 @@ export async function generateRequirements(enviroPath: string) {
     "generateHighLevelRequirements",
     false
   );
-  const reorder = config.get<boolean>("reorder", true);
-
   const args = [
     "-e",
     envPath,
@@ -106,7 +104,6 @@ export async function generateRequirements(enviroPath: string) {
     ...(generateHighLevelRequirements
       ? ["--generate-high-level-requirements"]
       : []),
-    ...(reorder ? [] : ["--no-reorder"]),
   ];
 
   try {
@@ -176,7 +173,6 @@ export async function generateTestsFromRequirements(
     true
   );
   const noTestExamples = config.get<boolean>("noTestExamples", false);
-  const reorder = config.get<boolean>("reorder", true);
   const funcDefs = config.get<boolean>("functionDefinitions", true);
   const allowUUTStubs = config.get<boolean>("enableUutStubbing", true);
   const batched = config.get<boolean>("batched", true);
@@ -201,7 +197,6 @@ export async function generateTestsFromRequirements(
     batched ? "--batched" : "--no-batched",
     ...(decomposeRequirements ? [] : ["--no-requirement-decomposition"]),
     ...(noTestExamples ? ["--no-test-examples"] : []),
-    ...(reorder ? [] : ["--no-reorder"]),
     ...(funcDefs ? [] : ["--no-func-defs"]),
     ...(allowUUTStubs ? [] : ["--no-allow-uut-stubs"]),
     "--allow-partial",

--- a/src/requirements/requirementsOperations.ts
+++ b/src/requirements/requirementsOperations.ts
@@ -3,11 +3,14 @@ import { showSettings } from "../utilities";
 import { refreshAllExtensionData } from "../testPane";
 import { loadTestScriptIntoEnvironment } from "../vcastAdapter";
 import { updateRequirementsAvailability } from "./availability";
-import { logCliError } from "./requirementsLog";
+import { logCliError, logCliOperation } from "./requirementsLog";
 import {
   CODE2REQS_EXECUTABLE_PATH,
   PANREQ_EXECUTABLE_PATH,
+  RECENT_REQS2TESTS_FLAGS,
   REQS2TESTS_EXECUTABLE_PATH,
+  reqs2testsSupportsDelta,
+  reqs2xSupportedFlags,
   setupReqs2XExecutablePaths,
 } from "./requirementsExecutables";
 import { runReqs2xTool } from "./processRunner";
@@ -62,6 +65,18 @@ export function initializeReqs2X(context: vscode.ExtensionContext) {
     "setContext",
     "vectorcastTestExplorer.reqs2xFeatureEnabled",
     featureEnabled
+  );
+  void publishDeltaSupportContext(featureEnabled);
+}
+
+// Hides the delta menu item when the installed reqs2tests predates --only-delta.
+// Not awaited, so the item stays hidden until the probe answers.
+async function publishDeltaSupportContext(featureEnabled: boolean) {
+  const supported = featureEnabled && (await reqs2testsSupportsDelta());
+  vscode.commands.executeCommand(
+    "setContext",
+    "vectorcastTestExplorer.reqs2xSupportsDelta",
+    supported
   );
 }
 
@@ -135,7 +150,8 @@ export async function generateRequirements(enviroPath: string) {
 
 export async function generateTestsFromRequirements(
   enviroPath: string,
-  unitOrFunctionName: string | null
+  unitOrFunctionName: string | null,
+  options: { onlyDelta?: boolean } = {}
 ) {
   const parentDir = path.dirname(enviroPath);
   const lowestDirname = path.basename(enviroPath);
@@ -172,10 +188,23 @@ export async function generateTestsFromRequirements(
     "decomposeRequirements",
     true
   );
-  const noTestExamples = config.get<boolean>("noTestExamples", false);
   const funcDefs = config.get<boolean>("functionDefinitions", true);
   const allowUUTStubs = config.get<boolean>("enableUutStubbing", true);
   const batched = config.get<boolean>("batched", true);
+  const fastMode = config.get<boolean>("fastMode", false);
+  const deduplicate = config.get<boolean>("deduplicateTests", true);
+  const allowPartial = config.get<boolean>("allowPartialTests", true);
+  const exampleSources = config.get<string[]>("testExampleSources", [
+    "environment",
+    "generated",
+  ]);
+
+  // Clamped because settings.json can be hand-edited past the schema minimum.
+  // Deprecated noTestExamples still wins while explicitly enabled.
+  const batchSize = Math.max(1, config.get<number>("batchSize", 4));
+  const maxTestExamples = config.get<boolean>("noTestExamples", false)
+    ? 0
+    : Math.max(0, config.get<number>("maxTestExamples", 3));
 
   const retries = config.get<number>("retries", 2);
   if (retries < 1) {
@@ -183,6 +212,25 @@ export async function generateTestsFromRequirements(
       "Retries must be greater than or equal to 1. Please check your settings."
     );
     return;
+  }
+
+  // --incremental-export is deliberately unused: we import one .tst at the end,
+  // and it force-disables deduplication. Same for code2reqs.
+  const supported = await reqs2xSupportedFlags(
+    REQS2TESTS_EXECUTABLE_PATH,
+    RECENT_REQS2TESTS_FLAGS
+  );
+
+  const exampleArgs: string[] = [];
+  if (maxTestExamples === 0) {
+    exampleArgs.push("--no-test-examples");
+  } else {
+    if (supported.has("--max-test-examples")) {
+      exampleArgs.push("--max-test-examples", maxTestExamples.toString());
+    }
+    if (exampleSources.length > 0 && supported.has("--test-examples-sources")) {
+      exampleArgs.push("--test-examples-sources", ...exampleSources);
+    }
   }
 
   const args = [
@@ -195,14 +243,26 @@ export async function generateTestsFromRequirements(
     "--retries",
     retries.toString(),
     batched ? "--batched" : "--no-batched",
+    ...(batched ? ["--batch-size", batchSize.toString()] : []),
     ...(decomposeRequirements ? [] : ["--no-requirement-decomposition"]),
-    ...(noTestExamples ? ["--no-test-examples"] : []),
     ...(funcDefs ? [] : ["--no-func-defs"]),
     ...(allowUUTStubs ? [] : ["--no-allow-uut-stubs"]),
-    "--allow-partial",
+    allowPartial ? "--allow-partial" : "--no-allow-partial",
+    ...(deduplicate ? [] : ["--no-deduplicate"]),
+    ...(fastMode && supported.has("--fast") ? ["--fast"] : []),
+    ...(options.onlyDelta ? ["--only-delta"] : []),
+    ...exampleArgs,
     "--json-events",
     "--requirement-keys",
   ];
+
+  // A delta run with nothing to do writes no tests, so a leftover .tst from an
+  // earlier run would otherwise be re-imported as fresh output.
+  try {
+    fs.rmSync(tstPath, { force: true });
+  } catch (err) {
+    logCliError(`Could not remove stale ${tstPath}: ${err}`);
+  }
 
   try {
     const { cancelled } = await runReqs2xTool({
@@ -210,16 +270,28 @@ export async function generateTestsFromRequirements(
       args,
       llm: true,
       progress: {
-        title: `Generating Requirement Tests for ${envName.split(".")[0]}`,
+        title: options.onlyDelta
+          ? `Generating Requirement Tests (untested or changed) for ${envName.split(".")[0]}`
+          : `Generating Requirement Tests for ${envName.split(".")[0]}`,
         logPrefix: "reqs2tests",
       },
     });
     if (cancelled) return;
 
+    if (!fs.existsSync(tstPath)) {
+      // reqs2tests reports the reason itself via an `info` event.
+      logCliOperation(
+        `reqs2tests wrote no test script to ${tstPath}; nothing to import`
+      );
+      return;
+    }
+
     await loadTestScriptIntoEnvironment(envName.split(".")[0], tstPath);
     await refreshAllExtensionData();
     vscode.window.showInformationMessage(
-      "Successfully generated tests for the requirements!"
+      options.onlyDelta
+        ? "Generated tests for untested and changed requirements. Tests written earlier for the changed requirements are kept — review and remove any that no longer apply."
+        : "Successfully generated tests for the requirements!"
     );
   } catch (err) {
     const message = `Error: ${err instanceof Error ? err.message : String(err)}`;


### PR DESCRIPTION
Catches the extension up with flags and events the Reqs2X CLI has gained.

**Settings** — `batchSize`, `fastMode`, `deduplicateTests`, `allowPartialTests`, `maxTestExamples`, `testExampleSources`. `--allow-partial` was hardcoded on with no way to disable it. `noTestExamples` is deprecated in favour of `maxTestExamples: 0` rather than removed, so existing configs keep working (note VS Code hides deprecated settings unless they have a value).

**Delta generation** — second command, *Generate Tests from Requirements (Untested or Changed Only)*, for `--only-delta`. A command rather than a setting because it is per-run intent. Its menu entry is gated on a context key so it stays hidden when the installed Reqs2X predates the flag. A delta run with nothing to do writes no `.tst`, so the target is removed up front and its absence tolerated afterwards — otherwise the previous run's script gets re-imported.

**nele provider** — was supported by the CLI but not selectable.

**Event handling** — `ProgressTracker` dropped `info` and `notice`. `info` already fires on the `--only-untraced` path we use, so inferring traceability on a fully-traced RGW finished with no visible output. `notice` carries the subscription nudge.

**`--no-reorder` removed** — no released CLI has ever accepted it, so turning the `reorder` setting off made code2reqs and reqs2tests exit non-zero.

**Version skew** — `panreqSupportsOnlyUntraced` was a bespoke single-flag cache; now `reqs2xSupportsFlag` / `reqs2xSupportedFlags` over one cached `--help` per binary. Recent flags are probed and dropped when absent; because settings cannot be gated on a context key the way a command can, generation warns when a setting the user actually chose was dropped.

Also drops the per-event log line from the availability refresh, which the `CCAST_.CFG` watcher was emitting several times a second while clicast was active.